### PR TITLE
Add ability to set a default sort attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ $users = QueryBuilder::for(User::class)
 // Will throw an `InvalidQuery` exception as `password` is not an allowed sorting property
 ```
 
+To define a default sort parameter that should be applied without explicitly adding it to the request, you can use the `defaultSort` method.
+
+``` php
+// GET /users
+$users = QueryBuilder::for(User::class)
+    ->defaultSort('name')
+    ->allowedSorts('name', 'street')
+    ->get();
+
+// Will retrieve the users sorted by name
+```
+
 ### Other query methods
 
 As the `QueryBuilder` extends Laravel's default Eloquent query builder you can use any method or macro you like. You can also specify a base query instead of the model FQCN:

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -13,6 +13,9 @@ class QueryBuilder extends Builder
     /** @var \Illuminate\Support\Collection */
     protected $allowedFilters;
 
+    /** @var string|null */
+    protected $defaultSort;
+
     /** @var \Illuminate\Support\Collection */
     protected $allowedSorts;
 
@@ -69,9 +72,18 @@ class QueryBuilder extends Builder
         return $this;
     }
 
+    public function defaultSort($sort): self
+    {
+        $this->defaultSort = $sort;
+
+        $this->addSortToQuery($this->request->sort($this->defaultSort));
+
+        return $this;
+    }
+
     public function allowedSorts(...$sorts): self
     {
-        if (! $sort = $this->request->sort()) {
+        if (! $this->request->sort()) {
             return $this;
         }
 
@@ -81,7 +93,7 @@ class QueryBuilder extends Builder
             $this->guardAgainstUnknownSorts();
         }
 
-        $this->addSortToQuery($sort);
+        $this->addSortToQuery($this->request->sort($this->defaultSort));
 
         return $this;
     }

--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -59,8 +59,8 @@ class QueryBuilderServiceProvider extends ServiceProvider
             return $filters->get(strtolower($filter));
         });
 
-        Request::macro('sort', function () {
-            return $this->query('sort');
+        Request::macro('sort', function ($default = null) {
+            return $this->query('sort', $default);
         });
     }
 }

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -75,6 +75,17 @@ class SortTest extends TestCase
         $this->assertEquals($eloquentQuery, $builderQuery);
     }
 
+    /** @test */
+    public function it_uses_default_sort_parameter()
+    {
+        $sortedModels = QueryBuilder::for(TestModel::class, new Request())
+            ->allowedSorts('name')
+            ->defaultSort('name')
+            ->get();
+
+        $this->assertSortedAscending($sortedModels, 'name');
+    }
+
     protected function createQueryFromSortRequest(string $sort): QueryBuilder
     {
         $request = new Request([


### PR DESCRIPTION
This PR adds the ability to define a default sort parameter to use when no sort query parameter is available.

It also fixes an issue that occurred when defining allowedSorts, but then perform a request without a sort parameter.