### PR TITLE
Do not handle empty sort query.

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -71,13 +71,17 @@ class QueryBuilder extends Builder
 
     public function allowedSorts(...$sorts): self
     {
+        if (! $sort = $this->request->sort()) {
+            return $this;
+        }
+
         $this->allowedSorts = collect($sorts);
 
         if (! $this->allowedSorts->contains('*')) {
             $this->guardAgainstUnknownSorts();
         }
 
-        $this->addSortToQuery($this->request->sort());
+        $this->addSortToQuery($sort);
 
         return $this;
     }


### PR DESCRIPTION
This is a fix for issue #8 

If nothing is returned from the `$this->request->sort()`, then we return early.