### PR TITLE
Escape LIKE queries

### DIFF
--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\QueryBuilder\Filters;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Builder;
 
 class FiltersPartial implements Filter
@@ -11,11 +12,20 @@ class FiltersPartial implements Filter
         if (is_array($value)) {
             return $query->where(function (Builder $query) use ($value, $property) {
                 foreach ($value as $partialValue) {
-                    $query->orWhere($property, 'LIKE', "%{$partialValue}%");
+                    $query
+                        ->orWhere($property, 'LIKE', DB::raw('? ESCAPE "\"'))
+                        ->addBinding("%{$this->escapeLike($partialValue)}%");
                 }
             });
         }
 
-        return $query->where($property, 'LIKE', "%{$value}%");
+        return $query
+            ->where($property, 'LIKE', DB::raw('? ESCAPE "\"'))
+            ->addBinding("%{$this->escapeLike($value)}%");
+    }
+
+    private function escapeLike(string $value): string
+    {
+        return addcslashes($value, '\%_');
     }
 }

--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -24,7 +24,7 @@ class FiltersPartial implements Filter
             ->addBinding("%{$this->escapeLike($value)}%");
     }
 
-    private function escapeLike(string $value): string
+    protected function escapeLike(string $value): string
     {
         return addcslashes($value, '\%_');
     }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -66,6 +66,22 @@ class FilterTest extends TestCase
     }
 
     /** @test */
+    public function it_escapes_like_query_on_partial()
+    {
+        $model1 = TestModel::create(['name' => 'FooXBarYBaz']);
+        $model2 = TestModel::create(['name' => 'Foo_Bar%Baz']);
+
+        $results = $this
+            ->createQueryFromFilterRequest([
+                'name' => 'Foo_Bar%Baz',
+            ])
+            ->allowedFilters('name')
+            ->get();
+
+        $this->assertEquals([$model2->id], $results->pluck('id')->all());
+    }
+
+    /** @test */
     public function it_can_filter_models_and_return_an_empty_collection()
     {
         $models = $this


### PR DESCRIPTION
I've made a PR to deal with this in core: laravel/framework#22864

Basically there was inconsistency between some DB servers, and also %, _ and \ weren't being escaped.