### PR TITLE
Add specific exceptions for every invalid query

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $users = QueryBuilder::for(User::class)
 // $users will contain all users with their posts, comments on their posts and permissions loaded
 ```
 
-When trying to include relationships that have not been allowed using `allowedIncludes()` an `InvalidQuery` exception will be thrown.
+When trying to include relationships that have not been allowed using `allowedIncludes()` an `InvalidIncludeQuery` exception will be thrown.
 
 Relation/include names will converted to camelCase when looking for the corresponding relationship on the model. This means `/users?include=blog-posts` will try to load the `blogPosts()` relationship on the `User` model.
 
@@ -115,7 +115,7 @@ Once the relationships are loaded on the results collection you can include them
 
 The `filter` query parmeters can be used to filter results by partial property value, exact property value or if a property value exists in a given array of values. You can also specify custom filters for more advanced queries.
 
-By default no filters are allowed. All filters have to be specified using `allowedFilters()`.
+By default no filters are allowed. All filters have to be specified using `allowedFilters()`. When trying to filter on properties that have not been allowed `allowedFilters()` an `InvalidFilterQuery` exception will be thrown.
 
 ``` php
 // GET /users?filter[name]=john&filter[email]=gmail
@@ -212,7 +212,7 @@ $users = QueryBuilder::for(User::class)->get();
 
 By default all model properties can be used to sort the results. However, you can use the `allowedSorts` method to limit which properties are allowed to be used in the request.
 
-When trying to sort by a property that's not specified in `allowedSorts()` an `InvalidQuery` exception will be thrown.
+When trying to sort by a property that's not specified in `allowedSorts()` an `InvalidSortQuery` exception will be thrown.
 
 ``` php
 // GET /users?sort=password
@@ -220,7 +220,7 @@ $users = QueryBuilder::for(User::class)
     ->allowedSorts('name')
     ->get();
 
-// Will throw an `InvalidQuery` exception as `password` is not an allowed sorting property
+// Will throw an `InvalidSortQuery` exception as `password` is not an allowed sorting property
 ```
 
 To define a default sort parameter that should be applied without explicitly adding it to the request, you can use the `defaultSort` method.

--- a/src/Exceptions/InvalidFilterQuery.php
+++ b/src/Exceptions/InvalidFilterQuery.php
@@ -8,10 +8,10 @@ use Illuminate\Support\Collection;
 class InvalidFilterQuery extends InvalidQuery
 {
     /** @var \Illuminate\Support\Collection */
-    private $unknownFilters;
+    public $unknownFilters;
 
     /** @var \Illuminate\Support\Collection */
-    private $allowedFilters;
+    public $allowedFilters;
 
     public function __construct(Collection $unknownFilters, Collection $allowedFilters)
     {
@@ -28,15 +28,5 @@ class InvalidFilterQuery extends InvalidQuery
     public static function filtersNotAllowed(Collection $unknownFilters, Collection $allowedFilters)
     {
         return new static(...func_get_args());
-    }
-
-    public function getUnknownFilters(): Collection
-    {
-        return $this->unknownFilters;
-    }
-
-    public function getAllowedFilters(): Collection
-    {
-        return $this->allowedFilters;
     }
 }

--- a/src/Exceptions/InvalidFilterQuery.php
+++ b/src/Exceptions/InvalidFilterQuery.php
@@ -20,7 +20,7 @@ class InvalidFilterQuery extends InvalidQuery
 
         $unknownFilters = $this->unknownFilters->implode(', ');
         $allowedFilters = $this->allowedFilters->implode(', ');
-        $message = "Given filter(s) `{$unknownFilters}` are not allowed. Allowed filters are `{$allowedFilters}`.";
+        $message = "Given filter(s) `{$unknownFilters}` are not allowed. Allowed filter(s) are `{$allowedFilters}`.";
 
         parent::__construct(Response::HTTP_BAD_REQUEST, $message);
     }

--- a/src/Exceptions/InvalidFilterQuery.php
+++ b/src/Exceptions/InvalidFilterQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\QueryBuilder\Exceptions;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
+
+class InvalidFilterQuery extends InvalidQuery
+{
+    /** @var \Illuminate\Support\Collection */
+    private $unknownFilters;
+
+    /** @var \Illuminate\Support\Collection */
+    private $allowedFilters;
+
+    public function __construct(Collection $unknownFilters, Collection $allowedFilters)
+    {
+        $this->unknownFilters = $unknownFilters;
+        $this->allowedFilters = $allowedFilters;
+
+        $unknownFilters = $this->unknownFilters->implode(', ');
+        $allowedFilters = $this->allowedFilters->implode(', ');
+        $message = "Given filter(s) `{$unknownFilters}` are not allowed. Allowed filters are `{$allowedFilters}`.";
+
+        parent::__construct(Response::HTTP_BAD_REQUEST, $message);
+    }
+
+    public static function filtersNotAllowed(Collection $unknownFilters, Collection $allowedFilters)
+    {
+        return new static(...func_get_args());
+    }
+
+    public function getUnknownFilters(): Collection
+    {
+        return $this->unknownFilters;
+    }
+
+    public function getAllowedFilters(): Collection
+    {
+        return $this->allowedFilters;
+    }
+}

--- a/src/Exceptions/InvalidIncludeQuery.php
+++ b/src/Exceptions/InvalidIncludeQuery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\QueryBuilder\Exceptions;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
+
+class InvalidIncludeQuery extends InvalidQuery
+{
+    /** @var \Illuminate\Support\Collection*/
+    private $unknownIncludes;
+
+    /** @var \Illuminate\Support\Collection */
+    private $allowedIncludes;
+
+    public function __construct(Collection $unknownIncludes, Collection $allowedIncludes)
+    {
+        $this->unknownIncludes = $unknownIncludes;
+        $this->allowedIncludes = $allowedIncludes;
+
+        $unknownIncludes = $unknownIncludes->implode(', ');
+        $allowedIncludes = $allowedIncludes->implode(', ');
+        $message = "Given include(s) `{$unknownIncludes}` are not allowed. Allowed includes are `{$allowedIncludes}`.";
+
+        parent::__construct(Response::HTTP_BAD_REQUEST, $message);
+    }
+
+    public static function includesNotAllowed(Collection $unknownIncludes, Collection $allowedIncludes)
+    {
+        return new static(...func_get_args());
+    }
+
+    public function getUnknownIncludes(): Collection
+    {
+        return $this->unknownIncludes;
+    }
+
+    public function getAllowedIncludes(): Collection
+    {
+        return $this->allowedIncludes;
+    }
+}

--- a/src/Exceptions/InvalidIncludeQuery.php
+++ b/src/Exceptions/InvalidIncludeQuery.php
@@ -7,11 +7,11 @@ use Illuminate\Support\Collection;
 
 class InvalidIncludeQuery extends InvalidQuery
 {
-    /** @var \Illuminate\Support\Collection */
-    private $unknownIncludes;
+    /** @var \Illuminate\Support\Collection*/
+    public $unknownIncludes;
 
     /** @var \Illuminate\Support\Collection */
-    private $allowedIncludes;
+    public $allowedIncludes;
 
     public function __construct(Collection $unknownIncludes, Collection $allowedIncludes)
     {
@@ -28,15 +28,5 @@ class InvalidIncludeQuery extends InvalidQuery
     public static function includesNotAllowed(Collection $unknownIncludes, Collection $allowedIncludes)
     {
         return new static(...func_get_args());
-    }
-
-    public function getUnknownIncludes(): Collection
-    {
-        return $this->unknownIncludes;
-    }
-
-    public function getAllowedIncludes(): Collection
-    {
-        return $this->allowedIncludes;
     }
 }

--- a/src/Exceptions/InvalidIncludeQuery.php
+++ b/src/Exceptions/InvalidIncludeQuery.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 
 class InvalidIncludeQuery extends InvalidQuery
 {
-    /** @var \Illuminate\Support\Collection*/
+    /** @var \Illuminate\Support\Collection */
     private $unknownIncludes;
 
     /** @var \Illuminate\Support\Collection */

--- a/src/Exceptions/InvalidIncludeQuery.php
+++ b/src/Exceptions/InvalidIncludeQuery.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 
 class InvalidIncludeQuery extends InvalidQuery
 {
-    /** @var \Illuminate\Support\Collection*/
+    /** @var \Illuminate\Support\Collection */
     public $unknownIncludes;
 
     /** @var \Illuminate\Support\Collection */

--- a/src/Exceptions/InvalidIncludeQuery.php
+++ b/src/Exceptions/InvalidIncludeQuery.php
@@ -20,7 +20,7 @@ class InvalidIncludeQuery extends InvalidQuery
 
         $unknownIncludes = $unknownIncludes->implode(', ');
         $allowedIncludes = $allowedIncludes->implode(', ');
-        $message = "Given include(s) `{$unknownIncludes}` are not allowed. Allowed includes are `{$allowedIncludes}`.";
+        $message = "Given include(s) `{$unknownIncludes}` are not allowed. Allowed include(s) are `{$allowedIncludes}`.";
 
         parent::__construct(Response::HTTP_BAD_REQUEST, $message);
     }

--- a/src/Exceptions/InvalidQuery.php
+++ b/src/Exceptions/InvalidQuery.php
@@ -2,39 +2,8 @@
 
 namespace Spatie\QueryBuilder\Exceptions;
 
-use Illuminate\Http\Response;
-use Illuminate\Support\Collection;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class InvalidQuery extends HttpException
+abstract class InvalidQuery extends HttpException
 {
-    public static function filtersNotAllowed(Collection $unknownFilters, Collection $allowedFilters)
-    {
-        $unknownFilters = $unknownFilters->implode(', ');
-        $allowedFilters = $allowedFilters->implode(', ');
-
-        $message = "Given filter(s) `{$unknownFilters}` are not allowed. Allowed filters are `{$allowedFilters}`.";
-
-        return new static(Response::HTTP_BAD_REQUEST, $message);
-    }
-
-    public static function sortsNotAllowed(Collection $unknownSorts, Collection $allowedSorts)
-    {
-        $unknownSorts = $unknownSorts->implode(', ');
-        $allowedSorts = $allowedSorts->implode(', ');
-
-        $message = "Given sort(s) `{$unknownSorts}` is not allowed. Allowed sorts are `{$allowedSorts}`.";
-
-        return new static(Response::HTTP_BAD_REQUEST, $message);
-    }
-
-    public static function includesNotAllowed(Collection $unknownIncludes, Collection $allowedIncludes)
-    {
-        $unknownIncludes = $unknownIncludes->implode(', ');
-        $allowedIncludes = $allowedIncludes->implode(', ');
-
-        $message = "Given include(s) `{$unknownIncludes}` are not allowed. Allowed includes are `{$allowedIncludes}`.";
-
-        return new static(Response::HTTP_BAD_REQUEST, $message);
-    }
 }

--- a/src/Exceptions/InvalidSortQuery.php
+++ b/src/Exceptions/InvalidSortQuery.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\QueryBuilder\Exceptions;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
+
+class InvalidSortQuery extends InvalidQuery
+{
+    /** @var \Illuminate\Support\Collection */
+    public $unknownSorts;
+
+    /** @var \Illuminate\Support\Collection */
+    public $allowedSorts;
+
+    public function __construct(string $unknownSort, Collection $allowedSorts)
+    {
+        $this->unknownSort = $unknownSort;
+        $this->allowedSorts = $allowedSorts;
+
+        $allowedSorts = $allowedSorts->implode(', ');
+        $unknownSorts = $unknownSorts->implode(', ');
+        $message = "Given sort(s) `{$unknownSorts}` is not allowed. Allowed sorts are `{$allowedSorts}`.";
+
+        parent::__construct(Response::HTTP_BAD_REQUEST, $message);
+    }
+
+    public static function sortsNotAllowed(string $unknownSort, Collection $allowedSorts)
+    {
+        return new static(...func_get_args());
+    }
+}

--- a/src/Exceptions/InvalidSortQuery.php
+++ b/src/Exceptions/InvalidSortQuery.php
@@ -13,9 +13,9 @@ class InvalidSortQuery extends InvalidQuery
     /** @var \Illuminate\Support\Collection */
     public $allowedSorts;
 
-    public function __construct(string $unknownSort, Collection $allowedSorts)
+    public function __construct(Collection $unknownSorts, Collection $allowedSorts)
     {
-        $this->unknownSort = $unknownSort;
+        $this->unknownSorts = $unknownSorts;
         $this->allowedSorts = $allowedSorts;
 
         $allowedSorts = $allowedSorts->implode(', ');
@@ -25,7 +25,7 @@ class InvalidSortQuery extends InvalidQuery
         parent::__construct(Response::HTTP_BAD_REQUEST, $message);
     }
 
-    public static function sortsNotAllowed(string $unknownSort, Collection $allowedSorts)
+    public static function sortsNotAllowed(Collection $unknownSorts, Collection $allowedSorts)
     {
         return new static(...func_get_args());
     }

--- a/src/Exceptions/InvalidSortQuery.php
+++ b/src/Exceptions/InvalidSortQuery.php
@@ -20,7 +20,7 @@ class InvalidSortQuery extends InvalidQuery
 
         $allowedSorts = $allowedSorts->implode(', ');
         $unknownSorts = $unknownSorts->implode(', ');
-        $message = "Given sort(s) `{$unknownSorts}` is not allowed. Allowed sorts are `{$allowedSorts}`.";
+        $message = "Given sort(s) `{$unknownSorts}` is not allowed. Allowed sort(s) are `{$allowedSorts}`.";
 
         parent::__construct(Response::HTTP_BAD_REQUEST, $message);
     }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -4,9 +4,10 @@ namespace Spatie\QueryBuilder;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Spatie\QueryBuilder\Exceptions\InvalidQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
 
 class QueryBuilder extends Builder
 {
@@ -165,7 +166,7 @@ class QueryBuilder extends Builder
         $diff = $filterNames->diff($allowedFilterNames);
 
         if ($diff->count()) {
-            throw InvalidQuery::filtersNotAllowed($diff, $allowedFilterNames);
+            throw InvalidFilterQuery::filtersNotAllowed($diff, $allowedFilterNames);
         }
     }
 
@@ -178,7 +179,7 @@ class QueryBuilder extends Builder
         $diff = $sorts->diff($this->allowedSorts);
 
         if ($diff->count()) {
-            throw InvalidQuery::sortsNotAllowed($diff, $this->allowedSorts);
+            throw InvalidSortQuery::sortsNotAllowed($diff, $this->allowedSorts);
         }
     }
 
@@ -189,7 +190,7 @@ class QueryBuilder extends Builder
         $diff = $includes->diff($this->allowedIncludes);
 
         if ($diff->count()) {
-            throw InvalidQuery::includesNotAllowed($diff, $this->allowedIncludes);
+            throw InvalidIncludeQuery::includesNotAllowed($diff, $this->allowedIncludes);
         }
     }
 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -5,9 +5,9 @@ namespace Spatie\QueryBuilder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
-use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
 
 class QueryBuilder extends Builder
 {

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -3,11 +3,12 @@
 namespace Spatie\QueryBuilder\Tests;
 
 use Illuminate\Http\Request;
+use Spatie\QueryBuilder\Exceptions\InvalidQuery;
 use Spatie\QueryBuilder\Filter;
 use Spatie\QueryBuilder\QueryBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
-use Spatie\QueryBuilder\Exceptions\InvalidQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 use Spatie\QueryBuilder\Filters\Filter as FilterInterface;
 
 class FilterTest extends TestCase
@@ -202,11 +203,20 @@ class FilterTest extends TestCase
     /** @test */
     public function it_guards_against_invalid_filters()
     {
-        $this->expectException(InvalidQuery::class);
+        $this->expectException(InvalidFilterQuery::class);
 
         $this
             ->createQueryFromFilterRequest(['name' => 'John'])
             ->allowedFilters('id');
+    }
+
+    /** @test */
+    public function an_invalid_filter_query_exception_contains_the_unknown_and_allowed_filters()
+    {
+        $exception = new InvalidFilterQuery(collect(['unknown filter']), collect(['allowed filter']));
+
+        $this->assertEquals(['unknown filter'], $exception->getUnknownFilters()->all());
+        $this->assertEquals(['allowed filter'], $exception->getAllowedFilters()->all());
     }
 
     protected function createQueryFromFilterRequest(array $filters): QueryBuilder

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -214,8 +214,8 @@ class FilterTest extends TestCase
     {
         $exception = new InvalidFilterQuery(collect(['unknown filter']), collect(['allowed filter']));
 
-        $this->assertEquals(['unknown filter'], $exception->getUnknownFilters()->all());
-        $this->assertEquals(['allowed filter'], $exception->getAllowedFilters()->all());
+        $this->assertEquals(['unknown filter'], $exception->unknownFilters->all());
+        $this->assertEquals(['allowed filter'], $exception->allowedFilters->all());
     }
 
     protected function createQueryFromFilterRequest(array $filters): QueryBuilder

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -3,7 +3,6 @@
 namespace Spatie\QueryBuilder\Tests;
 
 use Illuminate\Http\Request;
-use Spatie\QueryBuilder\Exceptions\InvalidQuery;
 use Spatie\QueryBuilder\Filter;
 use Spatie\QueryBuilder\QueryBuilder;
 use Illuminate\Database\Eloquent\Builder;

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -134,8 +134,8 @@ class IncludeTest extends TestCase
     {
         $exception = new InvalidIncludeQuery(collect(['unknown include']), collect(['allowed include']));
 
-        $this->assertEquals(['unknown include'], $exception->getUnknownIncludes()->all());
-        $this->assertEquals(['allowed include'], $exception->getAllowedIncludes()->all());
+        $this->assertEquals(['unknown include'], $exception->unknownIncludes->all());
+        $this->assertEquals(['allowed include'], $exception->allowedIncludes->all());
     }
 
     protected function createQueryFromIncludeRequest(string $includes): QueryBuilder

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
-use Spatie\QueryBuilder\Exceptions\InvalidQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
 
 class IncludeTest extends TestCase
 {
@@ -88,7 +88,7 @@ class IncludeTest extends TestCase
     /** @test */
     public function it_guards_against_invalid_includes()
     {
-        $this->expectException(InvalidQuery::class);
+        $this->expectException(InvalidIncludeQuery::class);
 
         $this
             ->createQueryFromIncludeRequest('random-model')
@@ -127,6 +127,15 @@ class IncludeTest extends TestCase
 
         $this->assertRelationLoaded($models, 'relatedModels');
         $this->assertRelationLoaded($models, 'otherRelatedModels');
+    }
+
+    /** @test */
+    public function an_invalid_include_query_exception_contains_the_unknown_and_allowed_includes()
+    {
+        $exception = new InvalidIncludeQuery(collect(['unknown include']), collect(['allowed include']));
+
+        $this->assertEquals(['unknown include'], $exception->getUnknownIncludes()->all());
+        $this->assertEquals(['allowed include'], $exception->getAllowedIncludes()->all());
     }
 
     protected function createQueryFromIncludeRequest(string $includes): QueryBuilder

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -68,8 +68,8 @@ class SortTest extends TestCase
     {
         $exception = new InvalidSortQuery('unknown sort', collect(['allowed sort']));
 
-        $this->assertEquals('unknown sort', $exception->getUnknownSort());
-        $this->assertEquals(['allowed sort'], $exception->getAllowedSorts()->all());
+        $this->assertEquals('unknown sort', $exception->unknownSort);
+        $this->assertEquals(['allowed sort'], $exception->allowedSorts->all());
     }
 
     /** @test */

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -66,9 +66,9 @@ class SortTest extends TestCase
     /** @test */
     public function an_invalid_sort_query_exception_contains_the_unknown_and_allowed_sorts()
     {
-        $exception = new InvalidSortQuery('unknown sort', collect(['allowed sort']));
+        $exception = new InvalidSortQuery(collect(['unknown sort']), collect(['allowed sort']));
 
-        $this->assertEquals('unknown sort', $exception->unknownSort);
+        $this->assertEquals(['unknown sort'], $exception->unknownSorts->all());
         $this->assertEquals(['allowed sort'], $exception->allowedSorts->all());
     }
 

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -5,7 +5,7 @@ namespace Spatie\QueryBuilder\Tests;
 use Illuminate\Http\Request;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
-use Spatie\QueryBuilder\Exceptions\InvalidQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
 use Spatie\QueryBuilder\Tests\Concerns\AssertsCollectionSorting;
 
 class SortTest extends TestCase
@@ -56,11 +56,20 @@ class SortTest extends TestCase
     /** @test */
     public function it_will_throw_an_exception_if_a_sort_property_is_not_allowed()
     {
-        $this->expectException(InvalidQuery::class);
+        $this->expectException(InvalidSortQuery::class);
 
         $this
             ->createQueryFromSortRequest('name')
             ->allowedSorts('id');
+    }
+
+    /** @test */
+    public function an_invalid_sort_query_exception_contains_the_unknown_and_allowed_sorts()
+    {
+        $exception = new InvalidSortQuery('unknown sort', collect(['allowed sort']));
+
+        $this->assertEquals('unknown sort', $exception->getUnknownSort());
+        $this->assertEquals(['allowed sort'], $exception->getAllowedSorts()->all());
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds a couple more specific exceptions to be able to better handle different query exceptions in userland.

- `InvalidFilterQuery` with `getAllowedFilters()` and `getUnknownFilters()`
- `InvalidIncludeQuery` with `getAllowedIncludes()` and `getUnknownIncludes()`
- `InvalidSortQuery` with `getAllowedSorts()` and `getUnknownSort()`

All these exceptions extend from `InvalidQuery`.