### PR TITLE
Add the ability to specify multiple sort parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,17 @@ $users = QueryBuilder::for(User::class)
 // Will retrieve the users sorted by name
 ```
 
+You can sort by multiple properties by separating them with a comma:
+
+``` php
+// GET /users?sort=name,-street
+$users = QueryBuilder::for(User::class)
+    ->allowedSorts('name', 'street')
+    ->get();
+
+// $users will be sorted by name in ascending order with a secondary sort on street in descending order.
+```
+
 ### Other query methods
 
 As the `QueryBuilder` extends Laravel's default Eloquent query builder you can use any method or macro you like. You can also specify a base query instead of the model FQCN:

--- a/src/Exceptions/InvalidQuery.php
+++ b/src/Exceptions/InvalidQuery.php
@@ -18,11 +18,12 @@ class InvalidQuery extends HttpException
         return new static(Response::HTTP_BAD_REQUEST, $message);
     }
 
-    public static function sortsNotAllowed(string $unknownSort, Collection $allowedSorts)
+    public static function sortsNotAllowed(Collection $unknownSorts, Collection $allowedSorts)
     {
+        $unknownSorts = $unknownSorts->implode(', ');
         $allowedSorts = $allowedSorts->implode(', ');
 
-        $message = "Given sort `{$unknownSort}` is not allowed. Allowed sorts are `{$allowedSorts}`.";
+        $message = "Given sort(s) `{$unknownSorts}` is not allowed. Allowed sorts are `{$allowedSorts}`.";
 
         return new static(Response::HTTP_BAD_REQUEST, $message);
     }

--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -62,5 +62,21 @@ class QueryBuilderServiceProvider extends ServiceProvider
         Request::macro('sort', function ($default = null) {
             return $this->query('sort', $default);
         });
+
+        Request::macro('sorts', function ($default = null) {
+            $sortParts = $this->sort();
+
+            if (! is_array($sortParts)) {
+                $sortParts = explode(',', $sortParts);
+            }
+
+            $sorts = collect($sortParts)->filter();
+
+            if ($sorts->isNotEmpty()) {
+                return $sorts;
+            }
+
+            return collect($default)->filter();
+        });
     }
 }

--- a/tests/RequestMacrosTest.php
+++ b/tests/RequestMacrosTest.php
@@ -25,6 +25,46 @@ class RequestMacrosTest extends TestCase
     }
 
     /** @test */
+    public function it_will_return_the_given_default_value_when_no_sort_query_param_is_specified()
+    {
+        $request = new Request();
+
+        $this->assertEquals('foobar', $request->sort('foobar'));
+    }
+
+    /** @test */
+    public function it_can_get_multiple_sort_parameters_from_the_request()
+    {
+        $request = new Request([
+            'sort' => 'foo,bar',
+        ]);
+
+        $expected = collect(['foo', 'bar']);
+
+        $this->assertEquals($expected, $request->sorts());
+    }
+
+    /** @test */
+    public function it_will_return_an_empty_collection_when_no_sort_query_params_are_specified()
+    {
+        $request = new Request();
+
+        $expected = collect();
+
+        $this->assertEquals($expected, $request->sorts());
+    }
+
+    /** @test */
+    public function it_will_return_the_given_default_value_when_no_sort_query_params_are_specified()
+    {
+        $request = new Request();
+
+        $expected = collect(['foobar']);
+
+        $this->assertEquals($expected, $request->sorts('foobar'));
+    }
+
+    /** @test */
     public function it_can_get_the_filter_query_params_from_the_request()
     {
         $request = new Request([

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -108,6 +108,21 @@ class SortTest extends TestCase
         $this->assertSortedAscending($sortedModels, 'name');
     }
 
+    /** @test */
+    public function it_can_sort_by_multiple_columns()
+    {
+        factory(TestModel::class, 3)->create(['name' => 'foo']);
+
+        $sortedModels = $this
+            ->createQueryFromSortRequest('name,-id')
+            ->allowedSorts('name', 'id')
+            ->get();
+
+        $expected = TestModel::orderBy('name')->orderByDesc('id');
+
+        $this->assertEquals($expected->pluck('id'), $sortedModels->pluck('id'));
+    }
+
     protected function createQueryFromSortRequest(string $sort): QueryBuilder
     {
         $request = new Request([


### PR DESCRIPTION
This introduces the ability to sort by multiple parameters as mentioned in the [JSON API Spec](http://jsonapi.org/format/#fetching-sorting) 

> An endpoint MAY support multiple sort fields by allowing comma-separated (U+002C COMMA, “,”) sort fields. Sort fields SHOULD be applied in the order specified.