### PR TITLE
Keep scopes and other builder properties from base query

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -28,7 +28,7 @@ class QueryBuilder extends Builder
     {
         parent::__construct(clone $builder->getQuery());
 
-        $this->initialiseFromBuilder($builder);
+        $this->initializeFromBuilder($builder);
 
         $this->request = $request ?? request();
 
@@ -43,13 +43,12 @@ class QueryBuilder extends Builder
      *
      * @param \Illuminate\Database\Eloquent\Builder $builder
      */
-    protected function initialiseFromBuilder(Builder $builder)
+    protected function initializeFromBuilder(Builder $builder)
     {
-        $this->setModel($builder->getModel());
+        $this->setModel($builder->getModel())
+            ->setEagerLoads($builder->getEagerLoads());
 
-        $this->setEagerLoads($builder->getEagerLoads());
-
-        $builder->macro('getProtected', function ($builder, $property) {
+        $builder->macro('getProtected', function (Builder $builder, string $property) {
             return $builder->{$property};
         });
 

--- a/tests/Models/RelatedModel.php
+++ b/tests/Models/RelatedModel.php
@@ -3,8 +3,8 @@
 namespace Spatie\QueryBuilder\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class RelatedModel extends Model
 {

--- a/tests/Models/RelatedModel.php
+++ b/tests/Models/RelatedModel.php
@@ -3,6 +3,7 @@
 namespace Spatie\QueryBuilder\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class RelatedModel extends Model

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -2,7 +2,9 @@
 
 namespace Spatie\QueryBuilder\Tests;
 
+use MongoDB\Driver\Query;
 use Spatie\QueryBuilder\QueryBuilder;
+use Spatie\QueryBuilder\Tests\Models\RelatedModel;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
 use Spatie\QueryBuilder\Tests\Models\ScopeModel;
 use Spatie\QueryBuilder\Tests\Models\SoftDeleteModel;
@@ -50,15 +52,53 @@ class QueryBuilderTest extends TestCase
     /** @test */
     public function it_can_query_global_scopes()
     {
-        $queryBuilder = QueryBuilder::for(ScopeModel::class);
-
         ScopeModel::create(['name' => 'John Doe']);
         ScopeModel::create(['name' => 'test']);
 
-        // Global scope ignores models with name "test"
-        $this->assertCount(1, $queryBuilder->get());
+        // Global scope on ScopeModel excludes models named "test"
+        $this->assertCount(1, QueryBuilder::for(ScopeModel::class)->get());
 
-        $this->assertCount(2, $queryBuilder->withoutGlobalScopes()->get());
+        $this->assertCount(2, QueryBuilder::for(ScopeModel::query()->withoutGlobalScopes())->get());
+
+        $this->assertCount(2, QueryBuilder::for(ScopeModel::class)->withoutGlobalScopes()->get());
+    }
+
+    /** @test */
+    public function it_keeps_eager_loaded_relationships_from_the_base_query()
+    {
+        TestModel::create(['name' => 'John Doe']);
+
+        $baseQuery = TestModel::with('relatedModels');
+        $queryBuilder = QueryBuilder::for($baseQuery);
+
+        $this->assertTrue($baseQuery->first()->relationLoaded('relatedModels'));
+        $this->assertTrue($queryBuilder->first()->relationLoaded('relatedModels'));
+    }
+
+    /** @test */
+    public function it_keeps_local_macros_added_to_the_base_query()
+    {
+        $baseQuery = TestModel::query();
+
+        $baseQuery->macro('customMacro', function ($builder) {
+            return $builder->where('name', 'Foo');
+        });
+
+        $queryBuilder = QueryBuilder::for($baseQuery);
+
+        $this->assertEquals($baseQuery->customMacro()->toSql(), $queryBuilder->customMacro()->toSql());
+    }
+
+    /** @test */
+    public function it_keeps_the_on_delete_callback_added_to_the_base_query()
+    {
+        $baseQuery = TestModel::query();
+
+        $baseQuery->onDelete(function () {
+            return 'onDelete called';
+        });
+
+        $this->assertEquals('onDelete called', QueryBuilder::for($baseQuery)->delete());
     }
 
     /** @test */

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\QueryBuilder\Tests;
 
-use MongoDB\Driver\Query;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
 use Spatie\QueryBuilder\Tests\Models\ScopeModel;
@@ -54,7 +53,7 @@ class QueryBuilderTest extends TestCase
         ScopeModel::create(['name' => 'John Doe']);
         ScopeModel::create(['name' => 'test']);
 
-        // Global scope on ScopeModel excludes models named "test"
+        // Global scope on ScopeModel excludes models named 'test'
         $this->assertCount(1, QueryBuilder::for(ScopeModel::class)->get());
 
         $this->assertCount(2, QueryBuilder::for(ScopeModel::query()->withoutGlobalScopes())->get());

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -4,7 +4,6 @@ namespace Spatie\QueryBuilder\Tests;
 
 use MongoDB\Driver\Query;
 use Spatie\QueryBuilder\QueryBuilder;
-use Spatie\QueryBuilder\Tests\Models\RelatedModel;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
 use Spatie\QueryBuilder\Tests\Models\ScopeModel;
 use Spatie\QueryBuilder\Tests\Models\SoftDeleteModel;


### PR DESCRIPTION
This PR makes sure the scopes, macro's, `onDelete` callback and eager loads defined on the base query are added to the QueryBuilder as well.

Fixes #13 
