### PR TITLE
Fix error when filter parameter is array

### DIFF
--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -36,7 +36,11 @@ class QueryBuilderServiceProvider extends ServiceProvider
                 return ! is_null($filter);
             });
 
-            $filters = $filters->map(function ($value) {
+            $filtersMapper = function ($value) {
+                if(is_array($value)) {
+                    return collect($value)->map($this)->all();
+                }
+
                 if (str_contains($value, ',')) {
                     return explode(',', $value);
                 }
@@ -50,7 +54,9 @@ class QueryBuilderServiceProvider extends ServiceProvider
                 }
 
                 return $value;
-            });
+            };
+
+            $filters = $filters->map($filtersMapper->bindTo($filtersMapper));
 
             if (is_null($filter)) {
                 return $filters;

--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -37,7 +37,7 @@ class QueryBuilderServiceProvider extends ServiceProvider
             });
 
             $filtersMapper = function ($value) {
-                if(is_array($value)) {
+                if (is_array($value)) {
                     return collect($value)->map($this)->all();
                 }
 

--- a/tests/RequestMacrosTest.php
+++ b/tests/RequestMacrosTest.php
@@ -133,8 +133,8 @@ class RequestMacrosTest extends TestCase
             'filter' => [
                 'foo' => 'bar,baz',
                 'bar' => [
-                    'foobar' => 'baz,bar'
-                ],                
+                    'foobar' => 'baz,bar',
+                ],
             ],
         ]);
 

--- a/tests/RequestMacrosTest.php
+++ b/tests/RequestMacrosTest.php
@@ -127,6 +127,23 @@ class RequestMacrosTest extends TestCase
     }
 
     /** @test */
+    public function it_will_map_array_in_filter_recursively_when_given_in_a_filter_query_string()
+    {
+        $request = new Request([
+            'filter' => [
+                'foo' => 'bar,baz',
+                'bar' => [
+                    'foobar' => 'baz,bar'
+                ],                
+            ],
+        ]);
+
+        $expected = collect(['foo' => ['bar', 'baz'], 'bar' => ['foobar'=> ['baz', 'bar']]]);
+
+        $this->assertEquals($expected, $request->filters());
+    }
+
+    /** @test */
     public function it_will_map_comma_separated_values_as_arrays_when_given_in_a_filter_query_string_and_get_those_by_key()
     {
         $request = new Request([


### PR DESCRIPTION
Hello.

In JSON API Spec there is no requirement that filter parameter should be string. So It's ok when user will pass something like `?filter[column_name][max]`, but currently in that case exception will be thrown. 

This PR make is possible to use arrays in filters.