### PR TITLE
Add allowedSearches to QueryBuilder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,26 @@ $users = QueryBuilder::for(User::class)
 // $users will be sorted by name in ascending order with a secondary sort on street in descending order.
 ```
 
+### Searching
+
+The `q` query parameter is used to search in your data by the defined columns in allowedSearches.
+
+You can define multiple columns to search in by separating them with a comma.
+
+```php
+QueryBuilder::for(User::class)
+    ->allowedSearches('first_name', 'last_name')
+    ->get();
+```
+
+You can also pass in an array to the `allowedSearches()` method.
+
+```php
+QueryBuilder::for(User::class)
+    ->allowedSearches(['first_name', 'last_name'])
+    ->get();
+```
+
 ### Other query methods
 
 As the `QueryBuilder` extends Laravel's default Eloquent query builder you can use any method or macro you like. You can also specify a base query instead of the model FQCN:

--- a/README.md
+++ b/README.md
@@ -264,9 +264,12 @@ The `q` query parameter is used to search in your data by the defined columns in
 You can define multiple columns to search in by separating them with a comma.
 
 ```php
+// GET /users?q=john
 QueryBuilder::for(User::class)
     ->allowedSearches('first_name', 'last_name')
     ->get();
+
+// $users will contain all users with a first_name or last_name that contains john
 ```
 
 You can also pass in an array to the `allowedSearches()` method.

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -135,6 +135,30 @@ class QueryBuilder extends Builder
         return $this;
     }
 
+    public function allowedSearches($columns): self
+    {
+        $columns = is_array($columns) ? $columns : func_get_args();
+
+        $columns = collect($columns);
+
+        $this->addSearchesToQuery($columns);
+
+        return $this;
+    }
+
+    protected function addSearchesToQuery(Collection $columns)
+    {
+        if (! $search = $this->request->search()) {
+            return;
+        }
+
+        $this->where(function ($query) use ($columns, $search) {
+            foreach ($columns as $column) {
+                $query->orWhere($column, 'LIKE', "%{$search}%");
+            }
+        });
+    }
+
     protected function addFiltersToQuery(Collection $filters)
     {
         $filters->each(function ($value, $property) {

--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -65,6 +65,10 @@ class QueryBuilderServiceProvider extends ServiceProvider
             return $filters->get(strtolower($filter));
         });
 
+        Request::macro('search', function () {
+            return $this->query('q');
+        });
+
         Request::macro('sort', function ($default = null) {
             return $this->query('sort', $default);
         });

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Spatie\QueryBuilder\Tests;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Spatie\QueryBuilder\QueryBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\QueryBuilder\Tests\Models\TestModel;
+
+class SearchTest extends TestCase
+{
+    /** @var \Illuminate\Support\Collection */
+    protected $models;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->models = factory(TestModel::class, 5)->create();
+    }
+
+    /** @test */
+    public function it_does_not_require_search_query()
+    {
+        $models = QueryBuilder::for(TestModel::class, new Request())
+            ->get();
+
+        $this->assertCount(TestModel::count(), $models);
+    }
+
+    /** @test */
+    public function it_can_search_by_name()
+    {
+        $model1 = TestModel::create(['name' => 'abc']);
+        $model2 = TestModel::create(['name' => 'def']);
+
+        $models = $this->createQueryFromSearchRequest('abc')
+            ->allowedSearches('name')
+            ->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals([$model1->id], $models->pluck('id')->all());
+    }
+
+    /** @test */
+    public function it_can_search_when_an_array_is_passed_in_allowed_searches()
+    {
+        $model1 = TestModel::create(['name' => 'abc']);
+        $model2 = TestModel::create(['name' => 'def']);
+
+        $models = $this->createQueryFromSearchRequest('abc')
+            ->allowedSearches(['name'])
+            ->get();
+
+        $this->assertCount(1, $models);
+        $this->assertEquals([$model1->id], $models->pluck('id')->all());
+    }
+
+    /** @test */
+    public function it_does_not_search_in_name_if_not_allowed()
+    {
+        $model1 = TestModel::create(['name' => 'abc']);
+        $model2 = TestModel::create(['name' => 'def']);
+
+        $models = $this->createQueryFromSearchRequest('abc')
+            ->get();
+
+        $this->assertCount(TestModel::count(), $models);
+    }
+
+    protected function createQueryFromSearchRequest(string $search): QueryBuilder
+    {
+        $request = new Request([
+            'q' => $search,
+        ]);
+
+        return QueryBuilder::for(TestModel::class, $request);
+    }
+}

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -3,9 +3,7 @@
 namespace Spatie\QueryBuilder\Tests;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\QueryBuilder;
-use Illuminate\Database\Eloquent\Model;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
 
 class SearchTest extends TestCase


### PR DESCRIPTION
Added the possibility to easily search in multiple columns by the `q` query parameter.

I know this sort of breaks the JSON API standard (nothing documented in relation to searching), but I like having this feature in my API's. If you like it I can eventually implement searching in relationship columns and probably more useful features.