### PR TITLE
Allow setting custom parameter names using query-builder config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,31 @@ You can install the package via composer:
 composer require spatie/laravel-query-builder
 ```
 
+You can optionally publish the config file with:
+```bash
+php artisan vendor:publish --provider="Spatie\QueryBuilder\QueryBuilderServiceProvider" --tag="config"
+```
+
+This is the contents of the published config file:
+```php
+return [
+
+    /**
+     * Define query parameter names used in the query.
+     */
+    'parameters' => [
+        'include' => 'include',
+
+        'filter' => 'filter',
+
+        'sort' => 'sort',
+
+        'fields' => 'fields',
+    ],
+
+];
+```
+
 ## Usage
 
 ### Including relationships

--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -2,6 +2,9 @@
 
 return [
 
+    /**
+     * Define query parameter names used in the query.
+     */
     'parameters' => [
         'include' => 'include',
 

--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+
+    'parameters' => [
+        'include' => 'include',
+
+        'filter' => 'filter',
+
+        'sort' => 'sort',
+
+        'fields' => 'fields',
+    ],
+
+];

--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -9,11 +9,18 @@ class QueryBuilderServiceProvider extends ServiceProvider
 {
     public function boot()
     {
+        $this->publishes([
+            __DIR__.'/../config/query-builder.php' => config_path('query-builder.php')
+        ], 'config');
+
+        $this->mergeConfigFrom(__DIR__.'/../config/query-builder.php', 'query-builder');
+
         Request::macro('includes', function ($include = null) {
-            $includeParts = $this->query('include');
+            $parameter = config('query-builder.parameters.include');
+            $includeParts = $this->query($parameter);
 
             if (! is_array($includeParts)) {
-                $includeParts = explode(',', strtolower($this->query('include')));
+                $includeParts = explode(',', strtolower($this->query($parameter)));
             }
 
             $includes = collect($includeParts)->filter();
@@ -26,7 +33,9 @@ class QueryBuilderServiceProvider extends ServiceProvider
         });
 
         Request::macro('filters', function ($filter = null) {
-            $filterParts = $this->query('filter');
+            $filterParts = $this->query(
+                config('query-builder.parameters.filter')
+            );
 
             if (! $filterParts) {
                 return collect();
@@ -66,11 +75,11 @@ class QueryBuilderServiceProvider extends ServiceProvider
         });
 
         Request::macro('sort', function ($default = null) {
-            return $this->query('sort', $default);
+            return $this->query(config('query-builder.parameters.sort'), $default);
         });
 
         Request::macro('fields', function ($default = null) {
-            return collect($this->query('fields', $default));
+            return collect($this->query(config('query-builder.parameters.fields'), $default));
         });
 
         Request::macro('sorts', function ($default = null) {

--- a/tests/RequestMacrosTest.php
+++ b/tests/RequestMacrosTest.php
@@ -17,6 +17,18 @@ class RequestMacrosTest extends TestCase
     }
 
     /** @test */
+    public function is_can_get_different_sort_query_parameter_name()
+    {
+        config(['query-builder.parameters.sort' => 'sorts']);
+
+        $request = new Request([
+            'sorts' => 'foobar',
+        ]);
+
+        $this->assertEquals('foobar', $request->sort());
+    }
+
+    /** @test */
     public function it_will_return_null_when_no_sort_query_param_is_specified()
     {
         $request = new Request();
@@ -77,6 +89,26 @@ class RequestMacrosTest extends TestCase
         $expected = collect([
                 'foo' => 'bar',
                 'baz' => 'qux',
+        ]);
+
+        $this->assertEquals($expected, $request->filters());
+    }
+
+    /** @test */
+    public function is_can_get_different_filter_query_parameter_name()
+    {
+        config(['query-builder.parameters.filter' => 'filters']);
+
+        $request = new Request([
+            'filters' => [
+                'foo' => 'bar',
+                'baz' => 'qux',
+            ],
+        ]);
+
+        $expected = collect([
+            'foo' => 'bar',
+            'baz' => 'qux',
         ]);
 
         $this->assertEquals($expected, $request->filters());
@@ -183,6 +215,20 @@ class RequestMacrosTest extends TestCase
     }
 
     /** @test */
+    public function is_can_get_different_include_query_parameter_name()
+    {
+        config(['query-builder.parameters.include' => 'includes']);
+
+        $request = new Request([
+            'includes' => 'foo,bar',
+        ]);
+
+        $expected = collect(['foo', 'bar']);
+
+        $this->assertEquals($expected, $request->includes());
+    }
+
+    /** @test */
     public function it_will_return_an_empty_collection_when_no_include_query_params_are_specified()
     {
         $request = new Request();
@@ -208,6 +254,22 @@ class RequestMacrosTest extends TestCase
     {
         $request = new Request([
             'fields' => [
+                'column' => 'name,email',
+            ],
+        ]);
+
+        $expected = collect(['column' => 'name,email']);
+
+        $this->assertEquals($expected, $request->fields());
+    }
+
+    /** @test */
+    public function is_can_get_different_include_fields_parameter_name()
+    {
+        config(['query-builder.parameters.fields' => 'field']);
+
+        $request = new Request([
+            'field' => [
                 'column' => 'name,email',
             ],
         ]);

--- a/tests/RequestMacrosTest.php
+++ b/tests/RequestMacrosTest.php
@@ -264,7 +264,7 @@ class RequestMacrosTest extends TestCase
     }
 
     /** @test */
-    public function is_can_get_different_include_fields_parameter_name()
+    public function is_can_get_different_fields_parameter_name()
     {
         config(['query-builder.parameters.fields' => 'field']);
 


### PR DESCRIPTION
This PR will allow using custom parameter names using config.

For example, if we want to change `filter` parameter to `filters` we will be able to achieve it using configuration. 

Publishing configuration file is optional.