### PR TITLE
Support allowedAppends()

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,35 @@ GET /posts?include=author&fields[author]=name
 
 All posts will be fetched including only the name of the author. 
 
+### Append attributes
+
+Sometimes you will want to append some custom attributes into result from a Model. This can be done using the `append` parameter.
+
+```
+class User extends Model{
+
+    getFullnameAttribute()
+    {
+        return $this->firstname.' '.$this->lastname;
+    }
+}
+```
+
+```
+// GET /users?append=fullname
+
+$users = QueryBuilder::for(User::class)
+    ->allowedAppends('fullname')
+    ->get();
+```
+
+Of course you can pass a list of attributes to be appended.
+
+```
+// GET /users?append=fullname,ranking
+```
+
+
 ### Other query methods
 
 As the `QueryBuilder` extends Laravel's default Eloquent query builder you can use any method or macro you like. You can also specify a base query instead of the model FQCN:

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Sometimes you will want to append some custom attributes into result from a Mode
 ```
 class User extends Model{
 
-    getFullnameAttribute()
+    public function getFullnameAttribute()
     {
         return $this->firstname.' '.$this->lastname;
     }

--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -15,6 +15,8 @@ return [
         'sort' => 'sort',
 
         'fields' => 'fields',
+
+        'append' => 'append',
     ],
 
 ];

--- a/src/Exceptions/InvalidAppendQuery.php
+++ b/src/Exceptions/InvalidAppendQuery.php
@@ -8,24 +8,24 @@ use Illuminate\Support\Collection;
 class InvalidAppendQuery extends InvalidQuery
 {
     /** @var \Illuminate\Support\Collection */
-    public $unknownAppends;
+    public $appendsNotAllowed;
 
     /** @var \Illuminate\Support\Collection */
     public $allowedAppends;
 
-    public function __construct(Collection $unknownAppends, Collection $allowedAppends)
+    public function __construct(Collection $appendsNotAllowed, Collection $allowedAppends)
     {
-        $this->unknownAppends = $unknownAppends;
+        $this->appendsNotAllowed = $appendsNotAllowed;
         $this->allowedAppends = $allowedAppends;
 
-        $unknownAppends = $unknownAppends->implode(', ');
+        $appendsNotAllowed = $appendsNotAllowed->implode(', ');
         $allowedAppends = $allowedAppends->implode(', ');
-        $message = "Given append(s) `{$unknownAppends}` are not allowed. Allowed append(s) are `{$allowedAppends}`.";
+        $message = "Given append(s) `{$appendsNotAllowed}` are not allowed. Allowed append(s) are `{$allowedAppends}`.";
 
         parent::__construct(Response::HTTP_BAD_REQUEST, $message);
     }
 
-    public static function appendsNotAllowed(Collection $unknownAppends, Collection $allowedAppends)
+    public static function appendsNotAllowed(Collection $appendsNotAllowed, Collection $allowedAppends)
     {
         return new static(...func_get_args());
     }

--- a/src/Exceptions/InvalidAppendQuery.php
+++ b/src/Exceptions/InvalidAppendQuery.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\QueryBuilder\Exceptions;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
+
+class InvalidAppendQuery extends InvalidQuery
+{
+    /** @var \Illuminate\Support\Collection */
+    public $unknownAppends;
+
+    /** @var \Illuminate\Support\Collection */
+    public $allowedAppends;
+
+    public function __construct(Collection $unknownAppends, Collection $allowedAppends)
+    {
+        $this->unknownAppends = $unknownAppends;
+        $this->allowedAppends = $allowedAppends;
+
+        $unknownAppends = $unknownAppends->implode(', ');
+        $allowedAppends = $allowedAppends->implode(', ');
+        $message = "Given append(s) `{$unknownAppends}` are not allowed. Allowed append(s) are `{$allowedAppends}`.";
+
+        parent::__construct(Response::HTTP_BAD_REQUEST, $message);
+    }
+
+    public static function appendsNotAllowed(Collection $unknownAppends, Collection $allowedAppends)
+    {
+        return new static(...func_get_args());
+    }
+}

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
 
 class QueryBuilder extends Builder
 {
@@ -24,7 +25,13 @@ class QueryBuilder extends Builder
     protected $allowedIncludes;
 
     /** @var \Illuminate\Support\Collection */
+    protected $allowedAppends;
+
+    /** @var \Illuminate\Support\Collection */
     protected $fields;
+
+    /** @var array */
+    protected $appends;
 
     /** @var \Illuminate\Http\Request */
     protected $request;
@@ -141,6 +148,19 @@ class QueryBuilder extends Builder
         return $this;
     }
 
+    public function allowedAppends($appends) : self
+    {
+        $appends = is_array($appends) ? $appends : func_get_args();
+
+        $this->allowedAppends = collect($appends);
+
+        $this->guardAgainstUnknownAppends();
+
+        $this->appends = $this->request->appends();
+
+        return $this;
+    }
+
     protected function parseSelectedFields()
     {
         $this->fields = $this->request->fields();
@@ -224,6 +244,16 @@ class QueryBuilder extends Builder
             });
     }
 
+    public function setAppendsToResult($result)
+    {
+        $result->map(function ($item) {
+            $item->append($this->appends->toArray());
+            return $item;
+        });
+            
+        return $result;
+    }
+
     protected function guardAgainstUnknownFilters()
     {
         $filterNames = $this->request->filters()->keys();
@@ -259,5 +289,27 @@ class QueryBuilder extends Builder
         if ($diff->count()) {
             throw InvalidIncludeQuery::includesNotAllowed($diff, $this->allowedIncludes);
         }
+    }
+
+    protected function guardAgainstUnknownAppends()
+    {
+        $appends = $this->request->appends();
+
+        $diff = $appends->diff($this->allowedAppends);
+
+        if ($diff->count()) {
+            throw InvalidAppendQuery::appendsNotAllowed($diff, $this->allowedAppends);
+        }
+    }
+
+    public function get($columns = ['*'])
+    {
+        $result = parent::get($columns);
+
+        if (count($this->appends) > 0) {
+            $result = $this->setAppendsToResult($result);
+        }
+
+        return $result;
     }
 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -6,9 +6,9 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
-use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
 
 class QueryBuilder extends Builder
 {
@@ -31,7 +31,7 @@ class QueryBuilder extends Builder
     protected $fields;
 
     /** @var array */
-    protected $appends;
+    protected $appends = [];
 
     /** @var \Illuminate\Http\Request */
     protected $request;
@@ -248,9 +248,10 @@ class QueryBuilder extends Builder
     {
         $result->map(function ($item) {
             $item->append($this->appends->toArray());
+
             return $item;
         });
-            
+
         return $result;
     }
 

--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -32,6 +32,23 @@ class QueryBuilderServiceProvider extends ServiceProvider
             return $includes->contains(strtolower($include));
         });
 
+        Request::macro('appends', function ($append = null) {
+            $parameter = config('query-builder.parameters.append');
+            $appendParts = $this->query($parameter);
+
+            if (! is_array($appendParts)) {
+                $appendParts = explode(',', strtolower($this->query($parameter)));
+            }
+
+            $appends = collect($appendParts)->filter();
+
+            if (is_null($append)) {
+                return $appends;
+            }
+
+            return $appends->contains(strtolower($append));
+        });
+
         Request::macro('filters', function ($filter = null) {
             $filterParts = $this->query(
                 config('query-builder.parameters.filter')

--- a/tests/AppendTest.php
+++ b/tests/AppendTest.php
@@ -3,9 +3,7 @@
 namespace Spatie\QueryBuilder\Tests;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\QueryBuilder;
-use Illuminate\Database\Eloquent\Model;
 use Spatie\QueryBuilder\Tests\Models\AppendModel;
 use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
 

--- a/tests/AppendTest.php
+++ b/tests/AppendTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Spatie\QueryBuilder\Tests;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Spatie\QueryBuilder\QueryBuilder;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\QueryBuilder\Tests\Models\AppendModel;
+use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
+
+class AppendTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        factory(AppendModel::class, 5)->create();
+    }
+
+    /** @test */
+    public function it_does_not_require_appends()
+    {
+        $models = QueryBuilder::for(AppendModel::class, new Request())
+            ->allowedAppends('fullname')
+            ->get();
+
+        $this->assertCount(AppendModel::count(), $models);
+    }
+
+    /** @test */
+    public function it_can_append_attributes()
+    {
+        $model = $this
+            ->createQueryFromAppendRequest('fullname')
+            ->allowedAppends('fullname')
+            ->first();
+
+        $this->assertAttributeLoaded($model, 'fullname');
+    }
+
+    /** @test */
+    public function it_can_append_case_insensitive()
+    {
+        $model = $this
+            ->createQueryFromAppendRequest('FullName')
+            ->allowedAppends('fullname')
+            ->first();
+
+        $this->assertAttributeLoaded($model, 'fullname');
+    }
+
+    /** @test */
+    public function it_guards_against_invalid_appends()
+    {
+        $this->expectException(InvalidAppendQuery::class);
+
+        $this
+            ->createQueryFromAppendRequest('random-attribute-to-append')
+            ->allowedAppends('attribute-to-append');
+    }
+
+    /** @test */
+    public function it_can_allow_multiple_appends()
+    {
+        $model = $this
+            ->createQueryFromAppendRequest('fullname')
+            ->allowedAppends('fullname', 'randomAttribute')
+            ->first();
+
+        $this->assertAttributeLoaded($model, 'fullname');
+    }
+
+    /** @test */
+    public function it_can_allow_multiple_appends_as_an_array()
+    {
+        $model = $this
+            ->createQueryFromAppendRequest('fullname')
+            ->allowedAppends(['fullname', 'randomAttribute'])
+            ->first();
+
+        $this->assertAttributeLoaded($model, 'fullname');
+    }
+
+    /** @test */
+    public function it_can_append_multiple_attributes()
+    {
+        $model = $this
+            ->createQueryFromAppendRequest('fullname,reversename')
+            ->allowedAppends(['fullname', 'reversename'])
+            ->first();
+
+        $this->assertAttributeLoaded($model, 'fullname');
+        $this->assertAttributeLoaded($model, 'reversename');
+    }
+
+    /** @test */
+    public function an_invalid_append_query_exception_contains_the_unknown_and_allowed_appends()
+    {
+        $exception = new InvalidAppendQuery(collect(['unknown append']), collect(['allowed append']));
+
+        $this->assertEquals(['unknown append'], $exception->unknownAppends->all());
+        $this->assertEquals(['allowed append'], $exception->allowedAppends->all());
+    }
+
+    protected function createQueryFromAppendRequest(string $appends): QueryBuilder
+    {
+        $request = new Request([
+            'append' => $appends,
+        ]);
+
+        return QueryBuilder::for(AppendModel::class, $request);
+    }
+
+    protected function assertAttributeLoaded(AppendModel $model, string $attribute)
+    {
+        $this->assertTrue(array_key_exists($attribute, $model->toArray()));
+    }
+}

--- a/tests/AppendTest.php
+++ b/tests/AppendTest.php
@@ -93,11 +93,11 @@ class AppendTest extends TestCase
     }
 
     /** @test */
-    public function an_invalid_append_query_exception_contains_the_unknown_and_allowed_appends()
+    public function an_invalid_append_query_exception_contains_the_not_allowed_and_allowed_appends()
     {
-        $exception = new InvalidAppendQuery(collect(['unknown append']), collect(['allowed append']));
+        $exception = new InvalidAppendQuery(collect(['not allowed append']), collect(['allowed append']));
 
-        $this->assertEquals(['unknown append'], $exception->unknownAppends->all());
+        $this->assertEquals(['not allowed append'], $exception->appendsNotAllowed->all());
         $this->assertEquals(['allowed append'], $exception->allowedAppends->all());
     }
 

--- a/tests/Models/AppendModel.php
+++ b/tests/Models/AppendModel.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\QueryBuilder\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AppendModel extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function getFullnameAttribute()
+    {
+        return $this->firstname .' '.$this->lastname;
+    }
+
+    public function getReversenameAttribute()
+    {
+        return $this->lastname.' ' .$this->firstname;
+    }
+}

--- a/tests/Models/AppendModel.php
+++ b/tests/Models/AppendModel.php
@@ -12,11 +12,11 @@ class AppendModel extends Model
 
     public function getFullnameAttribute()
     {
-        return $this->firstname .' '.$this->lastname;
+        return $this->firstname.' '.$this->lastname;
     }
 
     public function getReversenameAttribute()
     {
-        return $this->lastname.' ' .$this->firstname;
+        return $this->lastname.' '.$this->firstname;
     }
 }

--- a/tests/RequestMacrosTest.php
+++ b/tests/RequestMacrosTest.php
@@ -278,4 +278,51 @@ class RequestMacrosTest extends TestCase
 
         $this->assertEquals($expected, $request->fields());
     }
+
+    /** @test */
+    public function it_can_get_the_append_query_params_from_the_request()
+    {
+        $request = new Request([
+            'append' => 'foo,bar',
+        ]);
+
+        $expected = collect(['foo', 'bar']);
+
+        $this->assertEquals($expected, $request->appends());
+    }
+
+    /** @test */
+    public function is_can_get_different_append_query_parameter_name()
+    {
+        config(['query-builder.parameters.append' => 'appendit']);
+
+        $request = new Request([
+            'appendit' => 'foo,bar',
+        ]);
+
+        $expected = collect(['foo', 'bar']);
+
+        $this->assertEquals($expected, $request->appends());
+    }
+
+    /** @test */
+    public function it_will_return_an_empty_collection_when_no_append_query_params_are_specified()
+    {
+        $request = new Request();
+
+        $expected = collect();
+
+        $this->assertEquals($expected, $request->appends());
+    }
+
+    /** @test */
+    public function it_knows_if_a_specific_append_from_the_query_string_is_required()
+    {
+        $request = new Request([
+            'append' => 'foo,bar',
+        ]);
+
+        $this->assertEquals(false, $request->appends('baz'));
+        $this->assertEquals(true, $request->appends('bar'));
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,6 +25,12 @@ class TestCase extends Orchestra
             $table->string('name');
         });
 
+        $app['db']->connection()->getSchemaBuilder()->create('append_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('firstname');
+            $table->string('lastname');
+        });
+
         $app['db']->connection()->getSchemaBuilder()->create('soft_delete_models', function (Blueprint $table) {
             $table->increments('id');
             $table->softDeletes();

--- a/tests/factories/AppendModelFactory.php
+++ b/tests/factories/AppendModelFactory.php
@@ -6,6 +6,6 @@ use Spatie\QueryBuilder\Tests\Models\AppendModel;
 $factory->define(AppendModel::class, function (Faker $faker) {
     return [
         'firstname' => $faker->firstName,
-        'lastname' => $faker->lastName
+        'lastname' => $faker->lastName,
     ];
 });

--- a/tests/factories/AppendModelFactory.php
+++ b/tests/factories/AppendModelFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+use Faker\Generator as Faker;
+use Spatie\QueryBuilder\Tests\Models\AppendModel;
+
+$factory->define(AppendModel::class, function (Faker $faker) {
+    return [
+        'firstname' => $faker->firstName,
+        'lastname' => $faker->lastName
+    ];
+});


### PR DESCRIPTION
# Append attributes

Sometimes you will want to append some custom attributes into result from a Model. This can be done using the `append` parameter.

```
class User extends Model{

    getFullnameAttribute()
    {
        return $this->firstname.' '.$this->lastname;
    }
}
```

```
// GET /users?append=fullname

$users = QueryBuilder::for(User::class)
    ->allowedAppends('fullname')
    ->get();
```

Of course you can pass a list of attributes to be appended.

```
// GET /users?append=fullname,ranking
```