### PR TITLE
No longer requires explicit defining of parent includes in nested queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can load nested relationships using `.`:
 ``` php
 // GET /users?include=posts.comments,permissions
 $users = QueryBuilder::for(User::class)
-    ->allowedIncludes('posts', 'posts.comments', 'permissions')
+    ->allowedIncludes('posts.comments', 'permissions')
     ->get();
 
 // $users will contain all users with their posts, comments on their posts and permissions loaded

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -144,7 +144,7 @@ class QueryBuilder extends Builder
                 return collect(explode('.', $include))
                     ->reduce(function ($collection, $include) {
 
-                        if( $collection->isEmpty() ) {
+                        if ($collection->isEmpty()) {
                             return $collection->push($include);
                         }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -143,7 +143,6 @@ class QueryBuilder extends Builder
             ->flatMap(function ($include) {
                 return collect(explode('.', $include))
                     ->reduce(function ($collection, $include) {
-
                         if ($collection->isEmpty()) {
                             return $collection->push($include);
                         }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -139,7 +139,18 @@ class QueryBuilder extends Builder
     {
         $includes = is_array($includes) ? $includes : func_get_args();
 
-        $this->allowedIncludes = collect($includes);
+        $this->allowedIncludes = collect($includes)
+            ->flatMap(function ($include) {
+                return collect(explode('.', $include))
+                    ->reduce(function ($collection, $include) {
+
+                        if( $collection->isEmpty() ) {
+                            return $collection->push($include);
+                        }
+
+                        return $collection->push("{$collection->last()}.{$include}");
+                    }, collect());
+            });
 
         $this->guardAgainstUnknownIncludes();
 

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -62,6 +62,17 @@ class IncludeTest extends TestCase
     }
 
     /** @test */
+    public function it_can_include_model_relations_from_nested_model_relations()
+    {
+        $models = $this
+            ->createQueryFromIncludeRequest('related-models')
+            ->allowedIncludes('related-models.nested-related-models')
+            ->get();
+
+        $this->assertRelationLoaded($models, 'relatedModels');
+    }
+
+    /** @test */
     public function it_can_include_case_insensitive()
     {
         $models = $this


### PR DESCRIPTION
PR to cover #54.

Before:
```
// GET /users?include=posts
QueryBuilder::for(User::class)
    ->allowedIncludes('posts', 'posts.comments')
    ->get();
```

After:
```
// GET /users?include=posts
QueryBuilder::for(User::class)
    ->allowedIncludes('posts.comments')
    ->get();
```