### PR TITLE
Prepend fields with table name in database query

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -175,15 +175,21 @@ class QueryBuilder extends Builder
     {
         $this->fields = $this->request->fields();
 
-        $modelFields = $this->fields->get(
-            $this->getModel()->getTable()
-        );
+        $modelTableName = $this->getModel()->getTable();
+        $modelFields = $this->fields->get($modelTableName);
 
         if (! $modelFields) {
-            return;
+            $modelFields = '*';
         }
 
-        $this->select(explode(',', $modelFields));
+        $this->select($this->prependFieldsWithTableName(explode(',', $modelFields), $modelTableName));
+    }
+
+    protected function prependFieldsWithTableName(array $fields, string $tableName): array
+    {
+        return array_map(function ($field) use ($tableName) {
+            return "$tableName.$field";
+        }, $fields);
     }
 
     protected function getFieldsForRelatedTable(string $relation): array

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -9,12 +9,14 @@ use Spatie\QueryBuilder\Tests\Models\TestModel;
 class ColumnTest extends TestCase
 {
     protected $model;
+    protected $modelTableName;
 
     public function setUp()
     {
         parent::setUp();
 
         $this->model = factory(TestModel::class)->create();
+        $this->modelTableName = $this->model->getTable();
     }
 
     /** @test */
@@ -22,7 +24,7 @@ class ColumnTest extends TestCase
     {
         $queryBuilder = QueryBuilder::for(TestModel::class)->toSql();
 
-        $expected = TestModel::query()->toSql();
+        $expected = TestModel::query()->select("{$this->modelTableName}.*")->toSql();
 
         $this->assertEquals($expected, $queryBuilder);
     }
@@ -36,7 +38,7 @@ class ColumnTest extends TestCase
 
         $queryBuilder = QueryBuilder::for(TestModel::class, $request)->toSql();
 
-        $expected = TestModel::query()->select('name')->toSql();
+        $expected = TestModel::query()->select("{$this->modelTableName}.name")->toSql();
 
         $this->assertEquals($expected, $queryBuilder);
     }

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -11,12 +11,14 @@ use Spatie\QueryBuilder\Tests\Models\RelatedModel;
 class FieldsTest extends TestCase
 {
     protected $model;
+    protected $modelTableName;
 
     public function setUp()
     {
         parent::setUp();
 
         $this->model = factory(TestModel::class)->create();
+        $this->modelTableName = $this->model->getTable();
     }
 
     /** @test */
@@ -24,7 +26,7 @@ class FieldsTest extends TestCase
     {
         $queryBuilder = QueryBuilder::for(TestModel::class)->toSql();
 
-        $expected = TestModel::query()->toSql();
+        $expected = TestModel::query()->select("{$this->modelTableName}.*")->toSql();
 
         $this->assertEquals($expected, $queryBuilder);
     }
@@ -37,8 +39,9 @@ class FieldsTest extends TestCase
         ]);
 
         $queryBuilder = QueryBuilder::for(TestModel::class, $request)->toSql();
-
-        $expected = TestModel::query()->select('name', 'id')->toSql();
+        $expected = TestModel::query()
+                             ->select("{$this->modelTableName}.name", "{$this->modelTableName}.id")
+                             ->toSql();
 
         $this->assertEquals($expected, $queryBuilder);
     }
@@ -65,7 +68,7 @@ class FieldsTest extends TestCase
 
         $queryBuilder->first()->relatedModels;
 
-        $this->assertQueryLogContains('select "id" from "test_models"');
+        $this->assertQueryLogContains('select "test_models"."id" from "test_models"');
         $this->assertQueryLogContains('select "name" from "related_models"');
     }
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -28,8 +28,12 @@ class QueryBuilderTest extends TestCase
         $queryBuilder = QueryBuilder::for(TestModel::where('id', 1));
 
         $eloquentBuilder = TestModel::where('id', 1);
+        $modelTableName = (new TestModel)->getTable();
 
-        $this->assertEquals($eloquentBuilder->toSql(), $queryBuilder->toSql());
+        $this->assertEquals(
+            $eloquentBuilder->select("$modelTableName.*")->toSql(),
+            $queryBuilder->toSql()
+        );
     }
 
     /** @test */
@@ -79,7 +83,9 @@ class QueryBuilderTest extends TestCase
         $baseQuery = TestModel::query();
 
         $baseQuery->macro('customMacro', function ($builder) {
-            return $builder->where('name', 'Foo');
+            $modelTableName = (new TestModel)->getTable();
+
+            return $builder->select("$modelTableName.*")->where('name', 'Foo');
         });
 
         $queryBuilder = QueryBuilder::for($baseQuery);
@@ -105,8 +111,12 @@ class QueryBuilderTest extends TestCase
         $queryBuilderQuery = QueryBuilder::for(TestModel::class)
             ->named('john')
             ->toSql();
+        $modelTableName = (new TestModel)->getTable();
 
-        $expectedQuery = TestModel::query()->where('name', 'john')->toSql();
+        $expectedQuery = TestModel::query()
+                                  ->select("$modelTableName.*")
+                                  ->where('name', 'john')
+                                  ->toSql();
 
         $this->assertEquals($expectedQuery, $queryBuilderQuery);
     }

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -14,12 +14,14 @@ class SortTest extends TestCase
 
     /** @var \Illuminate\Support\Collection */
     protected $models;
+    protected $modelTableName;
 
     public function setUp()
     {
         parent::setUp();
 
         $this->models = factory(TestModel::class, 5)->create();
+        $this->modelTableName = $this->models->first()->getTable();
     }
 
     /** @test */
@@ -79,7 +81,7 @@ class SortTest extends TestCase
             ->allowedSorts('name')
             ->toSql();
 
-        $eloquentQuery = TestModel::query()->toSql();
+        $eloquentQuery = TestModel::query()->select("{$this->modelTableName}.*")->toSql();
 
         $this->assertEquals($eloquentQuery, $builderQuery);
     }


### PR DESCRIPTION
The resulting query from `QueryBuilder` did not work with database joins. Now joins can be used with the resulting database query. This should help with issue #36.