### PR TITLE
filter out orderBy duplicates

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -222,7 +222,7 @@ class QueryBuilder extends Builder
 
     protected function addSortsToQuery(Collection $sorts)
     {
-        $sorts
+        $this->filterDuplicates($sorts)
             ->each(function (string $sort) {
                 $descending = $sort[0] === '-';
 
@@ -230,6 +230,25 @@ class QueryBuilder extends Builder
 
                 $this->orderBy($key, $descending ? 'desc' : 'asc');
             });
+    }
+
+    protected function filterDuplicates(Collection $sorts): Collection
+    {
+        if (! is_array($orders = $this->getQuery()->orders)) {
+            return $sorts;
+        }
+
+        return $sorts->reject(function (string $sort) use ($orders) {
+            $toSort = [
+                'column' => ltrim($sort, '-'),
+                'direction' => ($sort[0] === '-') ? 'desc' : 'asc',
+            ];
+            foreach ($orders as $order) {
+                if ($order === $toSort) {
+                    return true;
+                }
+            }
+        });
     }
 
     protected function addIncludesToQuery(Collection $includes)

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -27,20 +27,24 @@ class SortTest extends TestCase
     /** @test */
     public function it_can_sort_a_collection_ascending()
     {
+        \DB::enableQueryLog();
         $sortedModels = $this
             ->createQueryFromSortRequest('name')
             ->get();
 
+        $this->assertSame(\DB::getQueryLog()[0]['query'], 'select "test_models".* from "test_models" order by "name" asc');
         $this->assertSortedAscending($sortedModels, 'name');
     }
 
     /** @test */
     public function it_can_sort_a_collection_descending()
     {
+        \DB::enableQueryLog();
         $sortedModels = $this
             ->createQueryFromSortRequest('-name')
             ->get();
 
+        $this->assertSame(\DB::getQueryLog()[0]['query'], 'select "test_models".* from "test_models" order by "name" desc');
         $this->assertSortedDescending($sortedModels, 'name');
     }
 
@@ -89,22 +93,26 @@ class SortTest extends TestCase
     /** @test */
     public function it_uses_default_sort_parameter()
     {
+        \DB::enableQueryLog();
         $sortedModels = QueryBuilder::for(TestModel::class, new Request())
             ->allowedSorts('name')
             ->defaultSort('name')
             ->get();
 
+        $this->assertSame(\DB::getQueryLog()[0]['query'], 'select "test_models".* from "test_models" order by "name" asc');
         $this->assertSortedAscending($sortedModels, 'name');
     }
 
     /** @test */
     public function it_can_allow_multiple_sort_parameters()
     {
+        \DB::enableQueryLog();
         $sortedModels = $this
             ->createQueryFromSortRequest('name')
             ->allowedSorts('id', 'name')
             ->get();
 
+        $this->assertSame(\DB::getQueryLog()[0]['query'], 'select "test_models".* from "test_models" order by "name" asc');
         $this->assertSortedAscending($sortedModels, 'name');
     }
 
@@ -123,6 +131,7 @@ class SortTest extends TestCase
     public function it_can_sort_by_multiple_columns()
     {
         factory(TestModel::class, 3)->create(['name' => 'foo']);
+        \DB::enableQueryLog();
 
         $sortedModels = $this
             ->createQueryFromSortRequest('name,-id')
@@ -130,7 +139,7 @@ class SortTest extends TestCase
             ->get();
 
         $expected = TestModel::orderBy('name')->orderByDesc('id');
-
+        $this->assertSame(\DB::getQueryLog()[0]['query'], 'select "test_models".* from "test_models" order by "name" asc, "id" desc');
         $this->assertEquals($expected->pluck('id'), $sortedModels->pluck('id'));
     }
 


### PR DESCRIPTION
This corrects the behavior specified here https://github.com/spatie/laravel-query-builder/issues/65
It removes `order by` duplicates for same column, same direction