### PR TITLE
Replace 'strtolower' for 'mb_strtolower'

### DIFF
--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -13,14 +13,14 @@ class FiltersPartial implements Filter
         if (is_array($value)) {
             return $query->where(function (Builder $query) use ($value, $sql) {
                 foreach ($value as $partialValue) {
-                    $partialValue = strtolower($partialValue);
+                    $partialValue = mb_strtolower($partialValue, 'UTF8');
 
                     $query->orWhereRaw($sql, ["%{$partialValue}%"]);
                 }
             });
         }
 
-        $value = strtolower($value);
+        $value = mb_strtolower($value, 'UTF8');
 
         return $query->whereRaw($sql, ["%{$value}%"]);
     }


### PR DESCRIPTION
Introduced in #70 

Using `lower()` in database:

```sql
#MySQL
SELECT LOWER(`SÃO PAULO`) FROM DUAL # são paulo
```

Using `strtolower()` in code:

```php
echo strtolower('SÃO PAULO'); # sÃo paulo
```

Using **mb_strtolower()** in code:

```php
echo mb_strtolower('SÃO PAULO', 'UTF8'); # são paulo
```


