### PR TITLE
Allow for instantiated custom filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-query-builder` will be documented in this file
 
+## 1.10.0 - 2018-06-12
+
+- add support for instantiated custom filter classes
+
 ## 1.9.6 - 2018-06-11
 
 - fix for using reserved SQL words as attributes in Postgres

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -3,6 +3,7 @@
 namespace Spatie\QueryBuilder;
 
 use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Filters\Filter as CustomFilter;
 use Spatie\QueryBuilder\Filters\FiltersExact;
 use Spatie\QueryBuilder\Filters\FiltersScope;
 use Spatie\QueryBuilder\Filters\FiltersPartial;
@@ -15,7 +16,7 @@ class Filter
     /** @var string */
     protected $property;
 
-    public function __construct(string $property, string $filterClass)
+    public function __construct(string $property, $filterClass)
     {
         $this->property = $property;
         $this->filterClass = $filterClass;
@@ -23,7 +24,7 @@ class Filter
 
     public function filter(Builder $builder, $value)
     {
-        $filterClass = new $this->filterClass;
+        $filterClass = $this->resolveFilterClass();
 
         ($filterClass)($builder, $value, $this->property);
     }
@@ -43,7 +44,7 @@ class Filter
         return new static($property, FiltersScope::class);
     }
 
-    public static function custom(string $property, string $filterClass) : self
+    public static function custom(string $property, $filterClass) : self
     {
         return new static($property, $filterClass);
     }
@@ -56,5 +57,14 @@ class Filter
     public function isForProperty(string $property): bool
     {
         return $this->property === $property;
+    }
+
+    private function resolveFilterClass(): CustomFilter
+    {
+        if ($this->filterClass instanceof CustomFilter) {
+            return $this->filterClass;
+        }
+
+        return new $this->filterClass;
     }
 }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -5,6 +5,7 @@ namespace Spatie\QueryBuilder\Tests;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Spatie\QueryBuilder\Filter;
+use Spatie\QueryBuilder\Filters\Filter as CustomFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
@@ -236,6 +237,36 @@ class FilterTest extends TestCase
         $this
             ->createQueryFromFilterRequest(['name' => 'John'])
             ->allowedFilters('id');
+    }
+
+    /** @test */
+    public function it_can_create_a_custom_filter_with_an_instantiated_filter()
+    {
+        $customFilter = new class('test1') implements CustomFilter {
+            /** @var string */
+            private $filter;
+
+            public function __construct(string $filter)
+            {
+                $this->filter = $filter;
+            }
+
+            public function __invoke(Builder $query, $value, string $property): Builder
+            {
+                return $query;
+            }
+        };
+
+        TestModel::create(['name' => 'abcdef']);
+
+        $results = $this
+            ->createQueryFromFilterRequest([
+                '*' => '*'
+            ])
+            ->allowedFilters('name', Filter::custom('*', $customFilter))
+            ->get();
+
+        $this->assertNotEmpty($results);
     }
 
     /** @test */


### PR DESCRIPTION
By allowing instantiated filter classes for custom filters, there's some nice features possible. For example a re-usable filter which searches several fields:

```
->allowedFilters(Filter::custom(
    'search',
    new FuzzyFilter('first_name', 'last_name', 'email')
))
```