### PR TITLE
Added ability to have custom sort classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This package allows you to filter, sort and include eloquent relations based on 
 Filtering an API request: `/users?filter[name]=John`:
 
 ```php
+use Spatie\QueryBuilder\QueryBuilder;
+
+// ...
+
 $users = QueryBuilder::for(User::class)
     ->allowedFilters('name')
     ->get();

--- a/src/Sort.php
+++ b/src/Sort.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Spatie\QueryBuilder;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Sorts\SortsField;
+use Spatie\QueryBuilder\Sorts\Sort as CustomSort;
+
+class Sort
+{
+    /** @var string */
+    protected $sortClass;
+
+    /** @var string */
+    protected $property;
+
+    public function __construct(string $property, $sortClass)
+    {
+        $this->property = $property;
+        $this->sortClass = $sortClass;
+    }
+
+    public function sort(Builder $builder, $descending)
+    {
+        $sortClass = $this->resolveSortClass();
+
+        ($sortClass)($builder, $descending, $this->property);
+    }
+
+    public static function field(string $property) : self
+    {
+        return new static($property, SortsField::class);
+    }
+
+    public static function custom(string $property, $sortClass) : self
+    {
+        return new static($property, $sortClass);
+    }
+
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    public function isForProperty(string $property): bool
+    {
+        return $this->property === $property;
+    }
+
+    private function resolveSortClass(): CustomSort
+    {
+        if ($this->sortClass instanceof CustomSort) {
+            return $this->sortClass;
+        }
+
+        return new $this->sortClass;
+    }
+}

--- a/src/Sorts/Sort.php
+++ b/src/Sorts/Sort.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\QueryBuilder\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+
+interface Sort
+{
+    public function __invoke(Builder $query, $descending, string $property) : Builder;
+}

--- a/src/Sorts/SortsField.php
+++ b/src/Sorts/SortsField.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\QueryBuilder\Sorts;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class SortsField implements Sort
+{
+    public function __invoke(Builder $query, $descending, string $property) : Builder
+    {
+        return $query->orderBy($property, $descending ? 'desc' : 'asc');
+    }
+}


### PR DESCRIPTION
This adds the ability to have custom sort classes. So why would you need or want a custom sort class? Doing so would allow users to sort by related models. Normal usage is the same as before. So if you just want to keep the standard sorting, you just add the sort fields like normal:

```
// GET /users?sort=name,-street
$users = QueryBuilder::for(User::class)
    ->allowedSorts('name', 'street')
    ->get();
```

So to add a custom sort you would so something like:

```
$posts = QueryBuilder::for(Post::class)
    ->allowedSorts('name', Sort::custom('user', UserCustomSort::class))
    ->get();
```

And a basic custom class would look like:

```
use Illuminate\Database\Eloquent\Builder;
use Spatie\QueryBuilder\Sorts\Sort;

class UserCustomSort implements Sort
{
    public function __invoke(Builder $query, $descending, string $property) : Builder
    {
        return $query->orderBy('name', $descending ? 'desc' : 'asc');
    }
}

```

Obviously you wouldn't want just a basic custom sort, but something that would be able to sort the related fields. This can be achieved by doing a sub select or you could do a join.

```
use Illuminate\Database\Eloquent\Builder;
use Spatie\QueryBuilder\Sorts\Sort;

class UserCustomSort implements Sort
{
    public function __invoke(Builder $query, $descending, string $property) : Builder
    {
        return $query
           ->addSubSelect('user', \App\User::select('name')->whereRaw('posts.user_id = users.id'))
           ->orderBy('name', $descending ? 'desc' : 'asc');
    }
}

```
While it passes all tests, this more than anything is a proof of concept. I think it could be improved upon. Let me know what you think. Thanks for providing such a great package. 
