### PR TITLE
Added Table of Contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,35 @@
 
 This package allows you to filter, sort and include eloquent relations based on a request. The `QueryBuilder` used in this package extends Laravel's default Eloquent builder. This means all your favorite methods and macros are still available. Query parameter names follow the [JSON API specification](http://jsonapi.org/) as closely as possible.
 
+## Table of Contents
+
+<!-- toc -->
+
+- [Basic usage](#basic-usage)
+- [Installation](#installation)
+- [Usage](#usage)
+  * [Including relationships](#including-relationships)
+  * [Filtering](#filtering)
+    + [Exact filters](#exact-filters)
+    + [Scope filters](#scope-filters)
+    + [Custom filters](#custom-filters)
+  * [Sorting](#sorting)
+  * [Selecting specific columns](#selecting-specific-columns)
+  * [Append attributes](#append-attributes)
+  * [Other query methods](#other-query-methods)
+    + [Pagination](#pagination)
+  * [Building queries at the front end](#building-queries-at-the-front-end)
+  * [Testing](#testing)
+  * [Changelog](#changelog)
+- [Contributing](#contributing)
+  * [Security](#security)
+- [Postcardware](#postcardware)
+- [Credits](#credits)
+- [Support us](#support-us)
+- [License](#license)
+
+<!-- tocstop -->
+
 ## Basic usage
 
 Filtering an API request: `/users?filter[name]=John`:


### PR DESCRIPTION
This PR adds a Table of Contents section to the README file.

I refer to the README quite often and find the links quite handy. It's very easy to generate. Here's how I do it:

1. Install the `markdown-toc` npm package globally:
```
npm i -g markdown-toc
```
2. Add the below to your README (where you want your Table of Contents to appear):
```
## Table of Contents
<!-- toc -->
<!-- tocstop -->
```
3.  Run the script in your application's directory:
```
markdown-toc README.md -i
```
4. Check the README file and commit your changes.
5. Profit.

Thanks.