### PR TITLE
Add allowedFields method

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,19 @@ The SQL query will look like this:
 SELECT "id", "name" FROM "users"
 ```
 
+you can also use the `allowedFields` method to limit which properties are allowed to be used in the request.
+
+When trying to select a column that's not specified in `allowedFields()` an `InvalidFieldQuery` exception will be thrown.
+
+``` php
+// GET /users?fields[users]=id
+$users = QueryBuilder::for(User::class)
+    ->allowedFields('name')
+    ->get();
+
+// Will throw an `InvalidFieldQuery` exception as `id` is not an allowed
+```
+
 Selecting fields for included models works the same way. This is especially useful when including entire relationships when you only need a couple of columns. Consider the following example:
 
 ```

--- a/src/Exceptions/InvalidFieldQuery.php
+++ b/src/Exceptions/InvalidFieldQuery.php
@@ -5,7 +5,7 @@ namespace Spatie\QueryBuilder\Exceptions;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
 
-class InvalidFieldsQuery extends InvalidQuery
+class InvalidFieldQuery extends InvalidQuery
 {
     /** @var \Illuminate\Support\Collection */
     public $unknownFields;

--- a/src/Exceptions/InvalidFieldsQuery.php
+++ b/src/Exceptions/InvalidFieldsQuery.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\QueryBuilder\Exceptions;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
+
+class InvalidFieldsQuery extends InvalidQuery
+{
+    /** @var \Illuminate\Support\Collection */
+    public $unknownFields;
+
+    /** @var \Illuminate\Support\Collection */
+    public $allowedFields;
+
+    public function __construct(Collection $unknownFields, Collection $allowedFields)
+    {
+        $this->unknownFields = $unknownFields;
+        $this->allowedFields = $allowedFields;
+
+        $unknownFields = $unknownFields->implode(', ');
+        $allowedFields = $allowedFields->implode(', ');
+        $message = "Given field(s) `{$unknownFields}` are not allowed. Allowed field(s) are `{$allowedFields}`.";
+
+        parent::__construct(Response::HTTP_BAD_REQUEST, $message);
+    }
+
+    public static function fieldsNotAllowed(Collection $unknownFields, Collection $allowedFields)
+    {
+        return new static(...func_get_args());
+    }
+}

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -118,7 +118,9 @@ class QueryBuilder extends Builder
 
         $this->allowedFields = collect($fields);
 
-        $this->guardAgainstUnknownFields();
+        if (! $this->allowedFields->contains('*')) {
+            $this->guardAgainstUnknownFields();
+        }
 
         return $this;
     }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -8,12 +8,16 @@ use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidFieldsQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
 
 class QueryBuilder extends Builder
 {
     /** @var \Illuminate\Support\Collection */
     protected $allowedFilters;
+
+    /** @var \Illuminate\Support\Collection */
+    protected $allowedFields;
 
     /** @var string|null */
     protected $defaultSort;
@@ -104,6 +108,17 @@ class QueryBuilder extends Builder
         $this->guardAgainstUnknownFilters();
 
         $this->addFiltersToQuery($this->request->filters());
+
+        return $this;
+    }
+
+    public function allowedFields($fields) : self
+    {
+        $fields = is_array($fields) ? $fields : func_get_args();
+
+        $this->allowedFields = collect($fields);
+
+        $this->guardAgainstUnknownFields();
 
         return $this;
     }
@@ -300,6 +315,19 @@ class QueryBuilder extends Builder
 
         if ($diff->count()) {
             throw InvalidFilterQuery::filtersNotAllowed($diff, $allowedFilterNames);
+        }
+    }
+
+    protected function guardAgainstUnknownFields()
+    {
+        $fields = $this->request->fields()->flatMap(function($value){
+            return explode(',',$value);
+        })->unique();
+
+        $diff = $fields->diff($this->allowedFields);
+
+        if ($diff->count()) {
+            throw InvalidFieldsQuery::fieldsNotAllowed($diff, $this->allowedFields);
         }
     }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
-use Spatie\QueryBuilder\Exceptions\InvalidFieldsQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidFieldQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
 
@@ -327,7 +327,7 @@ class QueryBuilder extends Builder
         $diff = $fields->diff($this->allowedFields);
 
         if ($diff->count()) {
-            throw InvalidFieldsQuery::fieldsNotAllowed($diff, $this->allowedFields);
+            throw InvalidFieldQuery::fieldsNotAllowed($diff, $this->allowedFields);
         }
     }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -6,8 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
-use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidFieldQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -7,8 +7,8 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
-use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidFieldsQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
 
 class QueryBuilder extends Builder
@@ -320,8 +320,8 @@ class QueryBuilder extends Builder
 
     protected function guardAgainstUnknownFields()
     {
-        $fields = $this->request->fields()->flatMap(function($value){
-            return explode(',',$value);
+        $fields = $this->request->fields()->flatMap(function ($value) {
+            return explode(',', $value);
         })->unique();
 
         $diff = $fields->diff($this->allowedFields);

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -47,7 +47,7 @@ class FieldsTest extends TestCase
     public function it_guards_against_invalid_fields()
     {
         $this->expectException(InvalidFieldsQuery::class);
-        
+
         $this
             ->createQueryFromFieldRequest(['test_models' => 'random-column'])
             ->allowedFields('name');

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
 use Spatie\QueryBuilder\Tests\Models\RelatedModel;
-use Spatie\QueryBuilder\Exceptions\InvalidFieldsQuery;
+use Spatie\QueryBuilder\Exceptions\InvalidFieldQuery;
 
 class FieldsTest extends TestCase
 {
@@ -46,7 +46,7 @@ class FieldsTest extends TestCase
     /** @test */
     public function it_guards_against_invalid_fields()
     {
-        $this->expectException(InvalidFieldsQuery::class);
+        $this->expectException(InvalidFieldQuery::class);
 
         $this
             ->createQueryFromFieldRequest(['test_models' => 'random-column'])


### PR DESCRIPTION
this **PR** , adds **allowedFields** method which will thorw **InvalidFieldQuery Exception** if the request has not allowed field .

also i think this **PR** may resolve #81  

``` php
// GET /users?fields[users]=id
$users = QueryBuilder::for(User::class)
    ->allowedFields('name')
    ->get();
 // Will throw an `InvalidFieldQuery` exception as `id` is not an allowed
```