### PR TITLE
Fix incorrect example about scope filter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 # Path-based git attributes
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+* text=auto
+* text eol=lf
 
 # Ignore all test and documentation with "export-ignore".
 /.gitattributes     export-ignore

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Consider the following scope on your model:
 ```php
 public function scopeStartsBefore(Builder $query, $date): Builder
 {
-    return $query->where('starts_at', '>=', Carbon::parse($date));
+    return $query->where('starts_at', '<=', Carbon::parse($date));
 }
 ```
 


### PR DESCRIPTION
I think `starts_at` before `$date` then `start_at <= $date`.
