### PR TITLE
Allow to filter by relation model properties

### DIFF
--- a/src/Filters/FiltersExact.php
+++ b/src/Filters/FiltersExact.php
@@ -2,16 +2,46 @@
 
 namespace Spatie\QueryBuilder\Filters;
 
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 
 class FiltersExact implements Filter
 {
+    protected $relationConstraints = [];
+
     public function __invoke(Builder $query, $value, string $property) : Builder
     {
+        if ($this->isRelationProperty($property)) {
+            return $this->withRelationConstraint($query, $value, $property);
+        }
+
         if (is_array($value)) {
             return $query->whereIn($property, $value);
         }
 
         return $query->where($property, $value);
+    }
+
+    protected function isRelationProperty(string $property) : bool
+    {
+        return Str::contains($property, '.') && ! in_array($property, $this->relationConstraints);
+    }
+
+    protected function withRelationConstraint(Builder $query, $value, string $property) : Builder
+    {
+        [$relation, $property] = collect(explode('.', $property))
+            ->pipe(function (Collection $parts) {
+                return [
+                    $parts->except(count($parts) - 1)->map('camel_case')->implode('.'),
+                    $parts->last(),
+                ];
+            });
+
+        return $query->whereHas($relation, function (Builder $query) use ($value, $relation, $property) {
+            $this->relationConstraints[] = $property = $query->getModel()->getTable().'.'.$property;
+
+            $this->__invoke($query, $value, $property);
+        });
     }
 }

--- a/src/Filters/FiltersExact.php
+++ b/src/Filters/FiltersExact.php
@@ -20,7 +20,7 @@ class FiltersExact implements Filter
             return $query->whereIn($property, $value);
         }
 
-        return $query->where($property, $value);
+        return $query->where($property, '=', $value);
     }
 
     protected function isRelationProperty(string $property) : bool

--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -4,10 +4,14 @@ namespace Spatie\QueryBuilder\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 
-class FiltersPartial implements Filter
+class FiltersPartial extends FiltersExact implements Filter
 {
     public function __invoke(Builder $query, $value, string $property): Builder
     {
+        if ($this->isRelationProperty($property)) {
+            return $this->withRelationConstraint($query, $value, $property);
+        }
+
         $wrappedProperty = $query->getQuery()->getGrammar()->wrap($property);
 
         $sql = "LOWER({$wrappedProperty}) LIKE ?";

--- a/tests/RelationFilterTest.php
+++ b/tests/RelationFilterTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Spatie\QueryBuilder\Tests;
+
+use Illuminate\Http\Request;
+use Spatie\QueryBuilder\Filter;
+use Spatie\QueryBuilder\QueryBuilder;
+use Spatie\QueryBuilder\Tests\Models\TestModel;
+
+class RelationFilterTest extends TestCase
+{
+    /** @var \Illuminate\Support\Collection */
+    protected $models;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->models = factory(TestModel::class, 5)->create();
+
+        $this->models->each(function (TestModel $model, $index) {
+            $model
+                ->relatedModels()->create(['name' => $model->name])
+                ->nestedRelatedModels()->create(['name' => 'test'.$index]);
+        });
+    }
+
+    /** @test */
+    public function it_can_filter_related_model_property()
+    {
+        $models = $this
+            ->createQueryFromFilterRequest([
+                'related-models.name' => $this->models->first()->name,
+            ])
+            ->allowedFilters('related-models.name')
+            ->get();
+
+        $this->assertCount(1, $models);
+    }
+
+    /** @test */
+    public function it_can_filter_results_based_on_the_partial_existence_of_a_property_in_an_array()
+    {
+        $results = $this
+            ->createQueryFromFilterRequest([
+                'related-models.nested-related-models.name' => 'est0,est1',
+            ])
+            ->allowedFilters('related-models.nested-related-models.name')
+            ->get();
+
+        $this->assertCount(2, $results);
+        $this->assertEquals([$this->models->get(0)->id, $this->models->get(1)->id], $results->pluck('id')->all());
+    }
+
+    /** @test */
+    public function it_can_filter_models_and_return_an_empty_collection()
+    {
+        $models = $this
+            ->createQueryFromFilterRequest([
+                'related-models.name' => 'None existing first name',
+            ])
+            ->allowedFilters('related-models.name')
+            ->get();
+
+        $this->assertCount(0, $models);
+    }
+
+    /** @test */
+    public function it_can_filter_related_nested_model_property()
+    {
+        $models = $this
+            ->createQueryFromFilterRequest([
+                'related-models.nested-related-models.name' => 'test',
+            ])
+            ->allowedFilters('related-models.nested-related-models.name')
+            ->get();
+
+        $this->assertCount(5, $models);
+    }
+
+    /** @test */
+    public function it_can_filter_related_model_and_related_nested_model_property()
+    {
+        $models = $this
+            ->createQueryFromFilterRequest([
+                'related-models.name' => $this->models->first()->name,
+                'related-models.nested-related-models.name' => 'test',
+            ])
+            ->allowedFilters('related-models.name', 'related-models.nested-related-models.name')
+            ->get();
+
+        $this->assertCount(1, $models);
+    }
+
+    /** @test */
+    public function it_can_filter_results_based_on_the_existence_of_a_property_in_an_array()
+    {
+        $testModel = TestModel::whereIn('id', [1, 2])->get();
+
+        $results = $this
+            ->createQueryFromFilterRequest([
+                'related-models.id' => $testModel->map(function ($model) {
+                    return $model->relatedModels->pluck('id');
+                })->flatten()->all(),
+            ])
+            ->allowedFilters(Filter::exact('related-models.id'))
+            ->get();
+
+        $this->assertCount(2, $results);
+        $this->assertEquals([1, 2], $results->pluck('id')->all());
+    }
+
+    /** @test */
+    public function it_can_filter_and_reject_results_by_exact_property()
+    {
+        $testModel = TestModel::create(['name' => 'John Testing Doe']);
+
+        $modelsResult = $this
+            ->createQueryFromFilterRequest([
+                'related-models.nested-related-models.name' => ' test ',
+            ])
+            ->allowedFilters(Filter::exact('related-models.nested-related-models.name'))
+            ->get();
+
+        $this->assertCount(0, $modelsResult);
+    }
+
+    protected function createQueryFromFilterRequest(array $filters): QueryBuilder
+    {
+        $request = new Request([
+            'filter' => $filters,
+        ]);
+
+        return QueryBuilder::for(TestModel::class, $request);
+    }
+}


### PR DESCRIPTION
resolves #101 

```php
$users = QueryBuilder::for(User::class)
    ->allowedFilters(['name', 'related-models.field_name'])
    ->get();
```