### PR TITLE
Feature/fixing magic functions and request helper for lumen

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -137,7 +137,7 @@ class QueryBuilder extends Builder
     public function allowedSorts($sorts) : self
     {
         $sorts = is_array($sorts) ? $sorts : func_get_args();
-        if (! $this->request->sorts()) {
+        if (! $this->request->get('sorts')) {
             return $this;
         }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -47,7 +47,7 @@ class QueryBuilder extends Builder
 
         $this->initializeFromBuilder($builder);
 
-        $this->request = $request ?? request();
+        $this->request = $request ?? app(Request::class);
 
         $this->parseSelectedFields();
 
@@ -92,7 +92,7 @@ class QueryBuilder extends Builder
             $baseQuery = ($baseQuery)::query();
         }
 
-        return new static($baseQuery, $request ?? request());
+        return new static($baseQuery, $request ?? app(Request::class));
     }
 
     /**


### PR DESCRIPTION
After trying to use this package in Lumen 5.6, we noticed that some magic functions and helpers doesn't exists in Lumen, such as `request` helper from Laravel, JessJNielsen's fork helped me, and solved one of the two problems when using Lumen, his fork fixed the magic functions issue, my fork fix the missing request helper for Lumen.