### PR TITLE
Allow for ignorable values on filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,36 @@ $users = QueryBuilder::for(User::class)
     ->get();
 // $users will contain all users that have the `createPosts` permission
 ```
+#### Ignored values for filters
+
+You can specify a set of ignored values for every filter. This allows you to not apply a filter when these values are submitted.
+```php
+QueryBuilder::for(User::class)
+    ->allowedFilters(Filter::exact('name')->ignore(null))
+    ->get();
+```
+The `ignore()` method takes one or more values, where each may be an array of ignored values. Each of the following calls are valid:
+* `ignore('should_be_ignored')`  
+* `ignore(null, '-1')`
+* `ignore([null, 'ignore_me'],['also_ignored'])`
+
+Given an array of values to filter for, only the subset of non-ignored values get passed to the filter. If all values are ignored, the filter does not get applied.
+
+```php
+// GET /user?name=forbidden,John Doe
+QueryBuilder::for(User::class)
+    ->allowedFilters(Filter::exact('name')->ignore('forbidden'))
+    ->get();
+
+// Only users where name matches 'John Doe'
+
+// GET /user?name=ignored,ignored_too
+QueryBuilder::for(User::class)
+    ->allowedFilters(Filter::exact('name')->ignore(['ignored', 'ignored_too']))
+    ->get();
+
+// Filter does not get applied
+```
 
 ### Sorting
 

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -101,6 +101,6 @@ class Filter
             return array_diff($property, $this->ignored->toArray());
         }
 
-        return !$this->ignored->contains($property) ? $property : null;
+        return ! $this->ignored->contains($property) ? $property : null;
     }
 }

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\QueryBuilder;
 
+use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Filters\FiltersExact;
 use Spatie\QueryBuilder\Filters\FiltersScope;
@@ -16,18 +17,29 @@ class Filter
     /** @var string */
     protected $property;
 
+    /** @var Collection */
+    protected $ignored;
+
     public function __construct(string $property, $filterClass)
     {
         $this->property = $property;
 
         $this->filterClass = $filterClass;
+
+        $this->ignored = Collection::make();
     }
 
     public function filter(Builder $builder, $value)
     {
+        $valueToFilter = $this->resolveValueForFiltering($value);
+
+        if (empty($valueToFilter)) {
+            return;
+        }
+
         $filterClass = $this->resolveFilterClass();
 
-        ($filterClass)($builder, $value, $this->property);
+        ($filterClass)($builder, $valueToFilter, $this->property);
     }
 
     public static function exact(string $property) : self
@@ -60,6 +72,20 @@ class Filter
         return $this->property === $property;
     }
 
+    public function ignore(...$values): self
+    {
+        $this->ignored = $this->ignored
+            ->merge($values)
+            ->flatten();
+
+        return $this;
+    }
+
+    public function getIgnored(): array
+    {
+        return $this->ignored->toArray();
+    }
+
     private function resolveFilterClass(): CustomFilter
     {
         if ($this->filterClass instanceof CustomFilter) {
@@ -67,5 +93,14 @@ class Filter
         }
 
         return new $this->filterClass;
+    }
+
+    private function resolveValueForFiltering($property)
+    {
+        if (is_array($property)) {
+            return array_diff($property, $this->ignored->toArray());
+        }
+
+        return !$this->ignored->contains($property) ? $property : null;
     }
 }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -340,7 +340,6 @@ class FilterTest extends TestCase
         $this->assertCount(1, $models);
     }
 
-
     protected function createQueryFromFilterRequest(array $filters): QueryBuilder
     {
         $request = new Request([

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -329,12 +329,13 @@ class FilterTest extends TestCase
     public function it_should_apply_the_filter_on_the_subset_of_allowed_values()
     {
         TestModel::create(['name' => 'John Doe']);
+        TestModel::create(['name' => 'John Deer']);
 
         $models = $this
             ->createQueryFromFilterRequest([
-                'name' => '-1,John Doe',
+                'name' => 'John Deer,John Doe',
             ])
-            ->allowedFilters(Filter::exact('name')->ignore('-1'))
+            ->allowedFilters(Filter::exact('name')->ignore('John Deer'))
             ->get();
 
         $this->assertCount(1, $models);

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -342,8 +342,6 @@ class FilterTest extends TestCase
         $this->assertCount(1, $models);
     }
 
-
-
     /** @test */
     public function it_can_take_an_argument_for_custom_column_name_resolution()
     {


### PR DESCRIPTION
This addresses  #104 and is inspired by #126 | Thanks @Propaganistas

## Changes to original implementation
* When the filter gets called with an array of values, the non-ignored subset propagates to the QueryBuilder
* Signature of `ignore()` allows for more flexible calls

The implementation makes use of `Illuminate\Support\Collection` for easier readability.
If requested, I can, of course, switch the implementation to use native array functions only. 