### PR TITLE
Fix detection of false-positives for ignored values

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -38,7 +38,7 @@ class Filter
     {
         $valueToFilter = $this->resolveValueForFiltering($value);
 
-        if (empty($valueToFilter)) {
+        if (is_null($valueToFilter)) {
             return;
         }
 
@@ -108,7 +108,8 @@ class Filter
     private function resolveValueForFiltering($property)
     {
         if (is_array($property)) {
-            return array_diff($property, $this->ignored->toArray());
+            $remainingProperties = array_diff($property, $this->ignored->toArray());
+            return ! empty($remainingProperties) ? $remainingProperties : null;
         }
 
         return ! $this->ignored->contains($property) ? $property : null;

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -376,6 +376,21 @@ class FilterTest extends TestCase
         $this->assertCount(1, $models);
     }
 
+    /** @test */
+    public function it_can_filter_using_boolean_flags()
+    {
+        TestModel::query()->update(['is_visible' => true]);
+        $filter = Filter::exact('is_visible');
+
+        $models = $this
+            ->createQueryFromFilterRequest(['is_visible' => 'false'])
+            ->allowedFilters($filter)
+            ->get();
+
+        $this->assertCount(0, $models);
+        $this->assertGreaterThan(0, TestModel::all()->count());
+    }
+
     protected function createQueryFromFilterRequest(array $filters): QueryBuilder
     {
         $request = new Request([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,7 @@ class TestCase extends Orchestra
             $table->increments('id');
             $table->timestamps();
             $table->string('name');
+            $table->boolean('is_visible')->default(true);
         });
 
         $app['db']->connection()->getSchemaBuilder()->create('append_models', function (Blueprint $table) {


### PR DESCRIPTION
Fixes #153 

If values to be filtered for are `falsy`, they get ignored by `empty()`.

I added a test to detect this case and changed the check to an explicit `is_null()` check.