### PR TITLE
Failing test for including morphTo relationship

### DIFF
--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
+use Spatie\QueryBuilder\Tests\Models\MorphModel;
 use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
 
 class IncludeTest extends TestCase
@@ -24,6 +25,8 @@ class IncludeTest extends TestCase
             $model
                 ->relatedModels()->create(['name' => 'Test'])
                 ->nestedRelatedModels()->create(['name' => 'Test']);
+
+            $model->morphModels()->create(['name' => 'Test']);
 
             $model->relatedThroughPivotModels()->create([
                 'id'   => $model->id + 1,
@@ -75,6 +78,31 @@ class IncludeTest extends TestCase
             ->get();
 
         $this->assertRelationLoaded($models, 'relatedModels');
+    }
+
+    /** @test */
+    public function it_can_include_morph_model_relations()
+    {
+        $models = $this
+            ->createQueryFromIncludeRequest('morph-models')
+            ->allowedIncludes('morph-models')
+            ->get();
+
+        $this->assertRelationLoaded($models, 'morphModels');
+    }
+
+    /** @test */
+    public function it_can_include_reverse_morph_model_relations()
+    {
+        $request = new Request([
+            'include' => 'parent'
+        ]);
+
+        $models = QueryBuilder::for(MorphModel::class, $request)
+            ->allowedIncludes('parent')
+            ->get();
+
+        $this->assertRelationLoaded($models, 'parent');
     }
 
     /** @test */

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -95,7 +95,7 @@ class IncludeTest extends TestCase
     public function it_can_include_reverse_morph_model_relations()
     {
         $request = new Request([
-            'include' => 'parent'
+            'include' => 'parent',
         ]);
 
         $models = QueryBuilder::for(MorphModel::class, $request)

--- a/tests/Models/MorphModel.php
+++ b/tests/Models/MorphModel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\QueryBuilder\Tests\Models;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class MorphModel extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function parent(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/Models/MorphModel.php
+++ b/tests/Models/MorphModel.php
@@ -2,9 +2,7 @@
 
 namespace Spatie\QueryBuilder\Tests\Models;
 
-use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class MorphModel extends Model

--- a/tests/Models/TestModel.php
+++ b/tests/Models/TestModel.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class TestModel extends Model
@@ -25,6 +26,11 @@ class TestModel extends Model
     public function relatedThroughPivotModels(): BelongsToMany
     {
         return $this->belongsToMany(RelatedThroughPivotModel::class, 'pivot_models');
+    }
+
+    public function morphModels(): MorphMany
+    {
+        return $this->morphMany(MorphModel::class, 'parent');
     }
 
     public function scopeNamed(Builder $query, string $name) : Builder

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -65,6 +65,12 @@ class TestCase extends Orchestra
             $table->increments('id');
             $table->string('name');
         });
+
+        $app['db']->connection()->getSchemaBuilder()->create('morph_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->morphs('parent');
+            $table->string('name');
+        });
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
Failing test showing that including morphTo relationships will throw QueryException caused by prepending selected fields with table name.

