### PR TITLE
Return if the sorts include an asterisk

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -145,7 +145,7 @@ class QueryBuilder extends Builder
     {
         $sorts = is_array($sorts) ? $sorts : func_get_args();
 
-        if (! $this->request->sorts()) {
+        if (! $this->request->sorts() || in_array('*', $sorts)) {
             return $this;
         }
 


### PR DESCRIPTION
Before the latest release `v1.13.0` it was possible to provide an `*` to the `allowedSorts` method - now it throws an exception.

It is a breaking change for several of my projects. This ensures it works as previously without altering the newly added functionality.