### PR TITLE
Enable the usage of an alias for a column name when using Sorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ $users = QueryBuilder::for(User::class)
 
 There may be occasions where it is not appropriate to expose the column name to the user.
 
-Similar to using [an alias when filtering]() you can do this with for sorts as well.
+Similar to using [an alias when filtering](#property-column-alias) you can do this with for sorts as well.
 
 The column name can be passed as optional parameter and defaults to the property string.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ use Spatie\QueryBuilder\Filter;
 
 // GET /users?filter[name]=John
 $users = QueryBuilder::for(User::class)
-	->allowedFilters(Filter::exact('name', 'user_name')) // public filter, column name
+    ->allowedFilters(Filter::exact('name', 'user_name')) // public filter, column name
     ->get();
 // filter by the column 'user_name'
 ```
@@ -389,14 +389,13 @@ There may be occasions where it is not appropriate to expose the column name to 
 
 Similar to using [an alias when filtering]() you can do this with for sorts as well.
 
-This follows the pattern: `'alias' => 'actual_column'`  
-Sorts without a `string` key must still be the name of the actual column.
+The column name can be passed as optional parameter and defaults to the property string.
 
  ``` php
- // GET /users?sort=name,-street
+ // GET /users?sort=-street
  $users = QueryBuilder::for(User::class)
-     ->allowedSorts(['name', 'street' => 'some_prefix_street'])
-     ->get();
+    ->allowedSorts(Sort::field('street', 'actual_column_street')
+    ->get();
  ```
 
 ### Selecting specific columns

--- a/README.md
+++ b/README.md
@@ -383,6 +383,22 @@ $users = QueryBuilder::for(User::class)
 // $users will be sorted by name in ascending order with a secondary sort on street in descending order.
 ```
 
+#### Using an alias for sorting
+
+There may be occasions where it is not appropriate to expose the column name to the user.
+
+Similar to using [an alias when filtering]() you can do this with for sorts as well.
+
+This follows the pattern: `'alias' => 'actual_column'`  
+Sorts without a `string` key must still be the name of the actual column.
+
+ ``` php
+ // GET /users?sort=name,-street
+ $users = QueryBuilder::for(User::class)
+     ->allowedSorts(['name', 'street' => 'some_prefix_street'])
+     ->get();
+ ```
+
 ### Selecting specific columns
 
 Sometimes you'll want to fetch only a couple fields to reduce the overall size of your SQL query. This can be done using the `fields` query parameter. The following fetch only the users' `id` and `name`

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -11,7 +11,7 @@ use Spatie\QueryBuilder\Filters\Filter as CustomFilter;
 
 class Filter
 {
-    /** @var string */
+    /** @var string|\Spatie\QueryBuilder\Filters\Filter */
     protected $filterClass;
 
     /** @var string */
@@ -23,7 +23,7 @@ class Filter
     /** @var Collection */
     protected $ignored;
 
-    public function __construct(string $property, $filterClass, $columnName = null)
+    public function __construct(string $property, $filterClass, ?string $columnName = null)
     {
         $this->property = $property;
 
@@ -47,7 +47,7 @@ class Filter
         ($filterClass)($builder, $valueToFilter, $this->columnName);
     }
 
-    public static function exact(string $property, $columnName = null) : self
+    public static function exact(string $property, ?string $columnName = null) : self
     {
         return new static($property, FiltersExact::class, $columnName);
     }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -149,9 +149,13 @@ class QueryBuilder extends Builder
             return $this;
         }
 
-        $this->allowedSorts = collect($sorts)->map(function ($sort) {
+        $this->allowedSorts = collect($sorts)->map(function ($sort, $alias) {
             if ($sort instanceof Sort) {
                 return $sort;
+            }
+
+            if (is_string($alias)) {
+                return Sort::field(ltrim($alias, '-'), ltrim($sort, '-'));
             }
 
             return Sort::field(ltrim($sort, '-'));
@@ -316,7 +320,7 @@ class QueryBuilder extends Builder
 
         return $sorts->reject(function (string $sort) use ($orders) {
             $toSort = [
-                'column' => ltrim($sort, '-'),
+                'column'    => ltrim($sort, '-'),
                 'direction' => ($sort[0] === '-') ? 'desc' : 'asc',
             ];
             foreach ($orders as $order) {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -149,13 +149,9 @@ class QueryBuilder extends Builder
             return $this;
         }
 
-        $this->allowedSorts = collect($sorts)->map(function ($sort, $alias) {
+        $this->allowedSorts = collect($sorts)->map(function ($sort) {
             if ($sort instanceof Sort) {
                 return $sort;
-            }
-
-            if (is_string($alias)) {
-                return Sort::field(ltrim($alias, '-'), ltrim($sort, '-'));
             }
 
             return Sort::field(ltrim($sort, '-'));

--- a/src/Sort.php
+++ b/src/Sort.php
@@ -12,17 +12,24 @@ class Sort
     /** @var string */
     protected $sortClass;
 
-    /** @var string */
+    /** @var string|\Spatie\QueryBuilder\Sorts\Sort */
     protected $property;
 
     /** @var string */
     protected $defaultDirection;
 
-    public function __construct(string $property, $sortClass)
+    /** @var string */
+    protected $columnName;
+
+    public function __construct(string $property, $sortClass, ?string $columnName = null)
     {
         $this->property = ltrim($property, '-');
+
         $this->sortClass = $sortClass;
+
         $this->defaultDirection = static::parsePropertyDirection($property);
+
+        $this->columnName = $columnName ?? $property;
     }
 
     public static function parsePropertyDirection(string $property): string
@@ -36,17 +43,17 @@ class Sort
 
         $descending = $descending ?? ($this->defaultDirection === SortDirection::DESCENDING);
 
-        ($sortClass)($builder, $descending, $this->property);
+        ($sortClass)($builder, $descending, $this->columnName);
     }
 
-    public static function field(string $property) : self
+    public static function field(string $property, ?string $columnName = null) : self
     {
-        return new static($property, SortsField::class);
+        return new static($property, SortsField::class, $columnName);
     }
 
-    public static function custom(string $property, $sortClass) : self
+    public static function custom(string $property, $sortClass, ?string $columnName = null) : self
     {
-        return new static($property, $sortClass);
+        return new static($property, $sortClass, $columnName);
     }
 
     public function getProperty(): string
@@ -66,5 +73,10 @@ class Sort
         }
 
         return new $this->sortClass;
+    }
+
+    public function getColumnName(): string
+    {
+        return $this->columnName;
     }
 }

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -224,8 +224,8 @@ class SortTest extends TestCase
     /** @test */
     public function it_can_sort_descending_with_an_alias()
     {
-        $this->createQueryFromSortRequest('-this_is_not_the_actual_column_name')
-            ->allowedSorts(['this_is_not_the_actual_column_name' => 'name'])
+        $this->createQueryFromSortRequest('-exposed_property_name')
+            ->allowedSorts(Sort::field('exposed_property_name', 'name'))
             ->get();
 
         $this->assertQueryExecuted('select * from "test_models" order by "name" desc');

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -179,16 +179,6 @@ class SortTest extends TestCase
     }
 
     /** @test */
-    public function it_takes_an_optional_alias_as_column_name()
-    {
-        $this->createQueryFromSortRequest('this_is_not_the_actual_column_name')
-            ->allowedSorts(['this_is_not_the_actual_column_name' => 'name'])
-            ->get();
-
-        $this->assertQueryExecuted('select * from "test_models" order by "name" asc');
-    }
-
-    /** @test */
     public function it_can_take_an_argument_for_custom_column_name_resolution()
     {
         $sort = Sort::custom('property_name', SortsField::class, 'property_column_name');

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -177,6 +177,26 @@ class SortTest extends TestCase
         $this->assertSortedAscending($sortedModels, 'name');
     }
 
+    /** @test */
+    public function it_takes_an_optional_alias_as_column_name()
+    {
+        $this->createQueryFromSortRequest('this_is_not_the_actual_column_name')
+            ->allowedSorts(['this_is_not_the_actual_column_name' => 'name'])
+            ->get();
+
+        $this->assertQueryExecuted('select * from "test_models" order by "name" asc');
+    }
+
+    /** @test */
+    public function it_can_sort_descending_with_an_alias()
+    {
+        $this->createQueryFromSortRequest('-this_is_not_the_actual_column_name')
+            ->allowedSorts(['this_is_not_the_actual_column_name' => 'name'])
+            ->get();
+
+        $this->assertQueryExecuted('select * from "test_models" order by "name" desc');
+    }
+
     protected function createQueryFromSortRequest(string $sort): QueryBuilder
     {
         $request = new Request([


### PR DESCRIPTION
This PR addresses #163

I'm not too fond of the solution [here](https://github.com/dominikb/laravel-query-builder/blob/777ac3c458211302df781ae0f2d8e9b218aff7ed/src/QueryBuilder.php#L157-L161)
```php
if (is_string($alias)) {
    return Sort::field(ltrim($alias, '-'), ltrim($sort, '-'));
}
return Sort::field(ltrim($sort, '-'));
```

Maybe someone can come up with a more readable solution?