### PR TITLE
Add Laravel 5.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,24 @@ matrix:
       env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
     - php: 7.1
       env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.1
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.2
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
     - php: 7.2
       env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
     - php: 7.2
       env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
     - php: 7.3
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*'
     - php: 7.3
       env: LARAVEL='5.6.*' TESTBENCH='3.6.*'
     - php: 7.3
       env: LARAVEL='5.7.*' TESTBENCH='3.7.*'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*'
 
 before_install:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/database": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/http": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0"
+        "illuminate/database": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/http": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.1|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.1|^7.0",
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0"
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR addresses #176 
I'm pretty sure this works. Laravel 5.8 is not that different from 5.7. 😉