### PR TITLE
Fix issue with descending default sort

### DIFF
--- a/src/Sort.php
+++ b/src/Sort.php
@@ -29,7 +29,7 @@ class Sort
 
         $this->defaultDirection = static::parsePropertyDirection($property);
 
-        $this->columnName = $columnName ?? $property;
+        $this->columnName = $columnName ?? $this->property;
     }
 
     public static function parsePropertyDirection(string $property): string

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -121,6 +121,18 @@ class SortTest extends TestCase
     }
 
     /** @test */
+    public function it_uses_default_descending_sort_parameter()
+    {
+        $sortedModels = QueryBuilder::for(TestModel::class, new Request())
+            ->allowedSorts('-name')
+            ->defaultSort('-name')
+            ->get();
+
+        $this->assertQueryExecuted('select * from "test_models" order by "name" desc');
+        $this->assertSortedDescending($sortedModels, 'name');
+    }
+
+    /** @test */
     public function it_can_allow_multiple_sort_parameters()
     {
         DB::enableQueryLog();


### PR DESCRIPTION
When setting a descending default sort without specifying a column name, the column name was set to the property name with the dash prepended.

This pull request fixes that issue by setting the column name to the processed property name instead and adds a test for this use case.