### PR TITLE
Multiple default sorts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,0 @@
-build
-composer.lock
-docs
-vendor
-.php_cs.cache
-coverage
-.phpunit.result.cache
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 .php_cs.cache
 coverage
 .phpunit.result.cache
+.idea

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -166,7 +166,7 @@ class QueryBuilder extends Builder
     }
 
     /**
-     * @param string|\Spatie\QueryBuilder\Sort $sorts
+     * @param array|string|\Spatie\QueryBuilder\Sort $sorts
      *
      * @return \Spatie\QueryBuilder\QueryBuilder
      */

--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -122,7 +122,11 @@ class QueryBuilderServiceProvider extends ServiceProvider
                 return $sorts;
             }
 
-            return collect($default)->filter();
+            if (! $default instanceof Collection) {
+                $default = collect($default);
+            }
+
+            return $default->filter();
         });
     }
 }

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -152,7 +152,7 @@ class SortTest extends TestCase
     }
 
     /** @test */
-    public function it_allows_custom_sort_class_for_default_sort_parameter()
+    public function it_allows_multiple_default_sort_parameters()
     {
         $sortClass = new class implements SortInterface {
             public function __invoke(Builder $query, $descending, string $property) : Builder

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -121,6 +121,25 @@ class SortTest extends TestCase
     }
 
     /** @test */
+    public function it_allows_default_custom_sort_class_parameter()
+    {
+        $sortClass = new class implements SortInterface {
+            public function __invoke(Builder $query, $descending, string $property) : Builder
+            {
+                return $query->orderBy('name', $descending ? 'desc' : 'asc');
+            }
+        };
+
+        $sortedModels = QueryBuilder::for(TestModel::class, new Request())
+            ->allowedSorts(Sort::custom('custom_name', get_class($sortClass)))
+            ->defaultSort(Sort::custom('custom_name', get_class($sortClass)))
+            ->get();
+
+        $this->assertQueryExecuted('select * from "test_models" order by "name" asc');
+        $this->assertSortedAscending($sortedModels, 'name');
+    }
+
+    /** @test */
     public function it_uses_default_descending_sort_parameter()
     {
         $sortedModels = QueryBuilder::for(TestModel::class, new Request())

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -152,6 +152,25 @@ class SortTest extends TestCase
     }
 
     /** @test */
+    public function it_allows_custom_sort_class_for_default_sort_parameter()
+    {
+        $sortClass = new class implements SortInterface {
+            public function __invoke(Builder $query, $descending, string $property) : Builder
+            {
+                return $query->orderBy('name', $descending ? 'desc' : 'asc');
+            }
+        };
+
+        $sortedModels = QueryBuilder::for(TestModel::class, new Request())
+            ->allowedSorts(Sort::custom('custom_name', get_class($sortClass)), 'id')
+            ->defaultSort(Sort::custom('custom_name', get_class($sortClass)), '-id')
+            ->get();
+
+        $this->assertQueryExecuted('select * from "test_models" order by "name" asc, "id" desc');
+        $this->assertSortedAscending($sortedModels, 'name');
+    }
+
+    /** @test */
     public function it_can_allow_multiple_sort_parameters()
     {
         DB::enableQueryLog();


### PR DESCRIPTION
This PR closes https://github.com/spatie/laravel-query-builder/issues/169

It allows the `defaultSort()` method to also accept an array of:

- Columns names as strings
- Custom sort classes

The method still allows for a single parameter to be passed for backwards compatibility.