### PR TITLE
Remove duplicate parsing of sort clauses

### DIFF
--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -271,6 +271,27 @@ class SortTest extends TestCase
         $this->assertQueryExecuted('select * from "test_models" order by "name" desc');
     }
 
+    /** @test */
+    public function it_does_not_add_sort_clauses_multiple_times()
+    {
+        $sql = QueryBuilder::for(TestModel::class)
+            ->defaultSort('name')
+            ->toSql();
+
+        $this->assertSame('select * from "test_models" order by "name" asc', $sql);
+    }
+
+    /** @test */
+    public function given_a_default_sort_a_sort_alias_will_still_be_resolved()
+    {
+        $sql = $this->createQueryFromSortRequest('-joined')
+            ->defaultSort('name')
+            ->allowedSorts(Sort::field('joined', 'created_at'))
+            ->toSql();
+
+        $this->assertSame('select * from "test_models" order by "created_at" desc', $sql);
+    }
+
     protected function createQueryFromSortRequest(string $sort): QueryBuilder
     {
         $request = new Request([


### PR DESCRIPTION
Depending on the call order sorts could be parsed multiple times.

"Normal" sorts usually get only parsed once, but default sorts could be parsed twice (e.g. when calling `getQuery()` multiple times).

This resulted in strange queries as described in #179.

This PR attempts to fix the above mentioned issue and reduce duplicated code.

The implementation is not yet finished and will surely result in conflicts with the current PR #214.

I will keep on working on this and adapt it to the changes in PR #214 once/if it gets merged.