### PR TITLE
Remove duplicate parsing of sort clauses

### DIFF
--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -76,11 +76,11 @@ trait SortsQuery
             return;
         }
 
-        $sorts = $this->request->sorts();
-
-        if ($sorts && ! $this->allowedSorts instanceof Collection) {
+        if (! $this->allowedSorts instanceof Collection) {
             $this->addDefaultSorts();
         }
+
+        $sorts = $this->request->sorts();
 
         if ($sorts->isEmpty()) {
             optional($this->defaultSorts)->each(function (Sort $sort) {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -3,7 +3,6 @@
 namespace Spatie\QueryBuilder;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Concerns\SortsQuery;
 use Spatie\QueryBuilder\Concerns\FiltersQuery;
@@ -50,9 +49,7 @@ class QueryBuilder extends Builder
 
     public function getQuery()
     {
-        if (! $this->allowedSorts instanceof Collection) {
-            $this->addDefaultSorts();
-        }
+        $this->parseSorts();
 
         if (! $this->allowedFields instanceof Collection) {
             $this->addAllRequestedFields();
@@ -66,9 +63,7 @@ class QueryBuilder extends Builder
      */
     public function get($columns = ['*'])
     {
-        if (! $this->allowedSorts instanceof Collection) {
-            $this->addDefaultSorts();
-        }
+        $this->parseSorts();
 
         if (! $this->allowedFields instanceof Collection) {
             $this->addAllRequestedFields();
@@ -85,9 +80,7 @@ class QueryBuilder extends Builder
 
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        if (! $this->allowedSorts instanceof Collection) {
-            $this->addDefaultSorts();
-        }
+        $this->parseSorts();
 
         if (! $this->allowedFields instanceof Collection) {
             $this->addAllRequestedFields();
@@ -98,9 +91,7 @@ class QueryBuilder extends Builder
 
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        if (! $this->allowedSorts instanceof Collection) {
-            $this->addDefaultSorts();
-        }
+        $this->parseSorts();
 
         if (! $this->allowedFields instanceof Collection) {
             $this->addAllRequestedFields();

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -309,6 +309,27 @@ class SortTest extends TestCase
         $this->assertQueryExecuted('select * from "test_models" order by "name" desc');
     }
 
+    /** @test */
+    public function it_does_not_add_sort_clauses_multiple_times()
+    {
+        $sql = QueryBuilder::for(TestModel::class)
+            ->defaultSort('name')
+            ->toSql();
+
+        $this->assertSame('select * from "test_models" order by "name" asc', $sql);
+    }
+
+    /** @test */
+    public function given_a_default_sort_a_sort_alias_will_still_be_resolved()
+    {
+        $sql = $this->createQueryFromSortRequest('-joined')
+            ->defaultSort('name')
+            ->allowedSorts(Sort::field('joined', 'created_at'))
+            ->toSql();
+
+        $this->assertSame('select * from "test_models" order by "created_at" desc', $sql);
+    }
+
     protected function createQueryFromSortRequest(string $sort): QueryBuilder
     {
         $request = new Request([

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -330,6 +330,18 @@ class SortTest extends TestCase
         $this->assertSame('select * from "test_models" order by "created_at" desc', $sql);
     }
 
+    /** @test */
+    public function late_specified_sorts_still_check_for_allowance()
+    {
+        $query = $this->createQueryFromSortRequest('created_at');
+
+        $this->assertSame('select * from "test_models" order by "created_at" asc', $query->toSql());
+
+        $this->expectException(InvalidSortQuery::class);
+
+        $query->allowedSorts(Sort::field('name-alias', 'name'));
+    }
+
     protected function createQueryFromSortRequest(string $sort): QueryBuilder
     {
         $request = new Request([


### PR DESCRIPTION
Depending on the call order sorts could be parsed multiple times.

"Normal" sorts usually get only parsed once, but default sorts could be parsed twice (e.g. when calling getQuery() multiple times).

Fixes #217, #179, #165

_New PR because I'm not smart enough to change the state of my Draft PR_ :1st_place_medal: 