### PR TITLE
Add support to get parameters from json of Illuminate\Http\Request

### DIFF
--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -17,10 +17,10 @@ class QueryBuilderRequest extends Request
     {
         $parameter = config('query-builder.parameters.include');
 
-        $includeParts = $this->query($parameter);
+        $includeParts = $this->getPartsOfRequest($parameter);
 
         if (! is_array($includeParts)) {
-            $includeParts = explode(',', strtolower($this->query($parameter)));
+            $includeParts = explode(',', strtolower($this->getPartsOfRequest($parameter)));
         }
 
         return collect($includeParts)->filter();
@@ -30,7 +30,7 @@ class QueryBuilderRequest extends Request
     {
         $appendParameter = config('query-builder.parameters.append');
 
-        $appendParts = $this->query($appendParameter);
+        $appendParts = $this->getPartsOfRequest($appendParameter);
 
         if (! is_array($appendParts)) {
             $appendParts = explode(',', strtolower($appendParts));
@@ -43,7 +43,7 @@ class QueryBuilderRequest extends Request
     {
         $filterParameter = config('query-builder.parameters.filter');
 
-        $filterParts = $this->query($filterParameter, []);
+        $filterParts = $this->getPartsOfRequest($filterParameter);
 
         if (is_string($filterParts)) {
             return collect();
@@ -60,7 +60,7 @@ class QueryBuilderRequest extends Request
     {
         $fieldsParameter = config('query-builder.parameters.fields');
 
-        $fieldsPerTable = collect($this->query($fieldsParameter));
+        $fieldsPerTable = collect($this->getPartsOfRequest($fieldsParameter));
 
         if ($fieldsPerTable->isEmpty()) {
             return collect();
@@ -76,7 +76,7 @@ class QueryBuilderRequest extends Request
      */
     public function sort()
     {
-        return $this->query(config('query-builder.parameters.sort'));
+        return $this->getPartsOfRequest(config('query-builder.parameters.sort'));
     }
 
     public function sorts(): Collection
@@ -111,5 +111,18 @@ class QueryBuilderRequest extends Request
         }
 
         return $value;
+    }
+
+    protected function getPartsOfRequest($parameter)
+    {
+        if (!empty($this->query($parameter, []))) {
+            return $this->query($parameter, []);
+        }
+
+        if(!empty($this->json($parameter, []))) {
+            return $this->json($parameter, []);
+        }
+
+        return [];
     }
 }

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -19,7 +19,7 @@ class QueryBuilderRequest extends Request
 
         $includeParts = $this->getPartsOfRequest($parameter);
 
-        if (! is_array($includeParts)) {
+        if (!is_array($includeParts)) {
             $includeParts = explode(',', strtolower($this->getPartsOfRequest($parameter)));
         }
 
@@ -32,7 +32,7 @@ class QueryBuilderRequest extends Request
 
         $appendParts = $this->getPartsOfRequest($appendParameter);
 
-        if (! is_array($appendParts)) {
+        if (!is_array($appendParts)) {
             $appendParts = explode(',', strtolower($appendParts));
         }
 
@@ -119,7 +119,7 @@ class QueryBuilderRequest extends Request
             return $this->query($parameter, []);
         }
 
-        if(!empty($this->json($parameter, []))) {
+        if (!empty($this->json($parameter, []))) {
             return $this->json($parameter, []);
         }
 

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -5,6 +5,7 @@ namespace Spatie\QueryBuilder\Tests;
 use Illuminate\Http\Request;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 class ColumnTest extends TestCase
 {
@@ -35,6 +36,21 @@ class ColumnTest extends TestCase
         $request = new Request([
             'fields' => ['test_models' => 'name'],
         ]);
+
+        $queryBuilder = QueryBuilder::for(TestModel::class, $request)->toSql();
+
+        $expected = TestModel::query()->select("{$this->modelTableName}.name")->toSql();
+
+        $this->assertEquals($expected, $queryBuilder);
+    }
+
+    /** @test */
+    public function it_can_fetch_only_required_columns_when_use_json_request()
+    {
+        $request = new Request();
+        $request->setJson(new ParameterBag([
+            'fields' => ['test_models' => 'name'],
+        ]));
 
         $queryBuilder = QueryBuilder::for(TestModel::class, $request)->toSql();
 

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -19,7 +19,7 @@ class FieldsTest extends TestCase
     {
         parent::setUp();
 
-        $this->model = factory(TestModel::class)->create();
+        $this->model          = factory(TestModel::class)->create();
         $this->modelTableName = $this->model->getTable();
     }
 
@@ -98,12 +98,12 @@ class FieldsTest extends TestCase
     {
         RelatedModel::create([
             'test_model_id' => $this->model->id,
-            'name' => 'related',
+            'name'          => 'related',
         ]);
 
         $request = new Request([
-            'fields' => [
-                'test_models' => 'id',
+            'fields'  => [
+                'test_models'    => 'id',
                 'related_models' => 'name',
             ],
             'include' => ['related-models'],
@@ -123,7 +123,7 @@ class FieldsTest extends TestCase
     public function it_can_allow_specific_fields_on_an_included_model()
     {
         $request = new Request([
-            'fields' => ['related_models' => 'id,name'],
+            'fields'  => ['related_models' => 'id,name'],
             'include' => ['related-models'],
         ]);
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -195,8 +195,7 @@ class FilterTest extends TestCase
     {
         $testModel = $this->models->first();
 
-        $filterClass = new class implements FilterInterface
-        {
+        $filterClass = new class implements FilterInterface {
             public function __invoke(Builder $query, $value, string $property): Builder
             {
                 return $query->where('name', $value);
@@ -278,8 +277,7 @@ class FilterTest extends TestCase
     /** @test */
     public function it_can_create_a_custom_filter_with_an_instantiated_filter()
     {
-        $customFilter = new class('test1') implements CustomFilter
-        {
+        $customFilter = new class('test1') implements CustomFilter {
             /** @var string */
             private $filter;
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -54,7 +54,6 @@ class FilterTest extends TestCase
     }
 
 
-
     /** @test */
     public function it_can_filter_partially_and_case_insensitive()
     {

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -31,7 +31,7 @@ class IncludeTest extends TestCase
             $model->morphModels()->create(['name' => 'Test']);
 
             $model->relatedThroughPivotModels()->create([
-                'id' => $model->id + 1,
+                'id'   => $model->id + 1,
                 'name' => 'Test',
             ]);
         });
@@ -227,11 +227,11 @@ class IncludeTest extends TestCase
     {
         $request = new Request();
 
-        if(!$json){
+        if (!$json) {
             $request->query = new ParameterBag([
                 'include' => $includes,
             ]);
-        }else{
+        } else {
             $request->setJson(new ParameterBag([
                 'include' => $includes,
             ]));
@@ -244,7 +244,7 @@ class IncludeTest extends TestCase
     {
         $hasModelWithoutRelationLoaded = $collection
             ->contains(function (Model $model) use ($relation) {
-                return ! $model->relationLoaded($relation);
+                return !$model->relationLoaded($relation);
             });
 
         $this->assertFalse($hasModelWithoutRelationLoaded, "The `{$relation}` relation was expected but not loaded.");

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -15,10 +15,9 @@ class QueryBuilderTest extends TestCase
         $this->getJson('/test-model?sort=name');
 
         $builder = QueryBuilder::for(TestModel::class);
-
         $this->assertEquals([
             'direction' => 'asc',
-            'column' => 'name',
+            'column'    => 'name',
         ], $builder->getQuery()->orders[0]);
     }
 
@@ -82,7 +81,7 @@ class QueryBuilderTest extends TestCase
     {
         TestModel::create(['name' => 'John Doe']);
 
-        $baseQuery = TestModel::with('relatedModels');
+        $baseQuery    = TestModel::with('relatedModels');
         $queryBuilder = QueryBuilder::for($baseQuery);
 
         $this->assertTrue($baseQuery->first()->relationLoaded('relatedModels'));

--- a/tests/RelationFilterTest.php
+++ b/tests/RelationFilterTest.php
@@ -98,7 +98,7 @@ class RelationFilterTest extends TestCase
     {
         $models = $this
             ->createQueryFromFilterRequest([
-                'related-models.name' => $this->models->first()->name,
+                'related-models.name'                       => $this->models->first()->name,
                 'related-models.nested-related-models.name' => 'test',
             ])
             ->allowedFilters('related-models.name', 'related-models.nested-related-models.name')
@@ -157,11 +157,11 @@ class RelationFilterTest extends TestCase
     {
         $request = new Request();
 
-        if(!$json) {
+        if (!$json) {
             $request->query = new ParameterBag([
                 'filter' => $filters,
             ]);
-        }else {
+        } else {
             $request->setJson(new ParameterBag([
                 'filter' => $filters,
             ]));

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -135,8 +135,9 @@ class SortTest extends TestCase
     /** @test */
     public function it_allows_default_custom_sort_class_parameter()
     {
-        $sortClass = new class implements SortInterface {
-            public function __invoke(Builder $query, $descending, string $property) : Builder
+        $sortClass = new class implements SortInterface
+        {
+            public function __invoke(Builder $query, $descending, string $property): Builder
             {
                 return $query->orderBy('name', $descending ? 'desc' : 'asc');
             }
@@ -166,8 +167,9 @@ class SortTest extends TestCase
     /** @test */
     public function it_allows_multiple_default_sort_parameters()
     {
-        $sortClass = new class implements SortInterface {
-            public function __invoke(Builder $query, $descending, string $property) : Builder
+        $sortClass = new class implements SortInterface
+        {
+            public function __invoke(Builder $query, $descending, string $property): Builder
             {
                 return $query->orderBy('name', $descending ? 'desc' : 'asc');
             }
@@ -224,8 +226,9 @@ class SortTest extends TestCase
     /** @test */
     public function it_can_sort_by_a_custom_sort_class()
     {
-        $sortClass = new class implements SortInterface {
-            public function __invoke(Builder $query, $descending, string $property) : Builder
+        $sortClass = new class implements SortInterface
+        {
+            public function __invoke(Builder $query, $descending, string $property): Builder
             {
                 return $query->orderBy('name', $descending ? 'desc' : 'asc');
             }
@@ -287,11 +290,11 @@ class SortTest extends TestCase
     {
         $request = new Request();
 
-        if(!$json) {
+        if (!$json) {
             $request->query = new ParameterBag([
                 'sort' => $sort,
             ]);
-        }else {
+        } else {
             $request->setJson(new ParameterBag([
                 'sort' => $sort,
             ]));

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -135,8 +135,7 @@ class SortTest extends TestCase
     /** @test */
     public function it_allows_default_custom_sort_class_parameter()
     {
-        $sortClass = new class implements SortInterface
-        {
+        $sortClass = new class implements SortInterface {
             public function __invoke(Builder $query, $descending, string $property): Builder
             {
                 return $query->orderBy('name', $descending ? 'desc' : 'asc');
@@ -167,8 +166,7 @@ class SortTest extends TestCase
     /** @test */
     public function it_allows_multiple_default_sort_parameters()
     {
-        $sortClass = new class implements SortInterface
-        {
+        $sortClass = new class implements SortInterface {
             public function __invoke(Builder $query, $descending, string $property): Builder
             {
                 return $query->orderBy('name', $descending ? 'desc' : 'asc');
@@ -226,8 +224,7 @@ class SortTest extends TestCase
     /** @test */
     public function it_can_sort_by_a_custom_sort_class()
     {
-        $sortClass = new class implements SortInterface
-        {
+        $sortClass = new class implements SortInterface {
             public function __invoke(Builder $query, $descending, string $property): Builder
             {
                 return $query->orderBy('name', $descending ? 'desc' : 'asc');


### PR DESCRIPTION
When I use 
```
$this->json('GET', '/endpoint', ['teste' => 'teste']) 
```
on my tests the parameters not getting by the QueryBuilderRequest correctly and It is because the Request put this ones in *json* property and QueryBuilderRequest get from query method. 


