### PR TITLE
Allow sorting on related model fields

### DIFF
--- a/src/ColumnNameSanitizer.php
+++ b/src/ColumnNameSanitizer.php
@@ -15,7 +15,7 @@ class ColumnNameSanitizer
      * Column names are alphanumeric strings that can contain
      * underscores (`_`) but can't start with a number.
      */
-    private const VALID_COLUMN_NAME_REGEX = '/^(?![0-9])[A-Za-z0-9_-]*$/';
+    private const VALID_COLUMN_NAME_REGEX = '/^(?![0-9])[.A-Za-z0-9_-]*$/';
 
     public static function sanitize(string $column): string
     {

--- a/src/ColumnNameSanitizer.php
+++ b/src/ColumnNameSanitizer.php
@@ -15,7 +15,7 @@ class ColumnNameSanitizer
      * Column names are alphanumeric strings that can contain
      * underscores (`_`) but can't start with a number.
      */
-    private const VALID_COLUMN_NAME_REGEX = '/^(?![0-9])[.A-Za-z0-9_-]*$/';
+    private const VALID_COLUMN_NAME_REGEX = '/^(?![0-9])[A-Za-z0-9._-]*$/';
 
     public static function sanitize(string $column): string
     {


### PR DESCRIPTION
It currently blocks sorting on a relationship because the regex doesn't allow for dot notation.

`->defaultSort('relation.field')`