### PR TITLE
execute query from params

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -36,13 +36,18 @@ class QueryBuilder extends Builder
      *
      * @param string|\Illuminate\Database\Query\Builder $baseQuery Model class or base query builder
      * @param \Illuminate\Http\Request                  $request
+     * @param array                                     $params
      *
      * @return \Spatie\QueryBuilder\QueryBuilder
      */
-    public static function for($baseQuery, ?Request $request = null): self
+    public static function for($baseQuery, ?Request $request = null, array $params = []): self
     {
         if (is_string($baseQuery)) {
             $baseQuery = ($baseQuery)::query();
+        }
+
+        if (null === $request && !empty($params)) {
+            $request = new Request($params);
         }
 
         return new static($baseQuery, $request ?? request());

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -46,7 +46,7 @@ class QueryBuilder extends Builder
             $baseQuery = ($baseQuery)::query();
         }
 
-        if (null === $request && !empty($params)) {
+        if (null === $request && ! empty($params)) {
             $request = new Request($params);
         }
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
 use Spatie\QueryBuilder\Tests\Models\ScopeModel;
 use Spatie\QueryBuilder\Tests\Models\SoftDeleteModel;
+use Spatie\QueryBuilder\Filter;
 
 class QueryBuilderTest extends TestCase
 {
@@ -161,5 +162,23 @@ class QueryBuilderTest extends TestCase
             ->toSql();
 
         $this->assertEquals($usingSortFirst, $usingFilterFirst);
+    }
+
+    /** @test */
+    public function it_executes_query_from_params()
+    {
+        $params = [
+            'filter' => ['name' => 'test']
+        ];
+
+        $queryBuilder = QueryBuilder::for(TestModel::class, null, $params)
+            ->allowedFilters(Filter::exact('name'))
+            ->toSql();
+
+        $expectedQuery = TestModel::query()
+            ->where('name', 'test')
+            ->toSql();
+
+        $this->assertEquals($queryBuilder, $expectedQuery);
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -168,7 +168,7 @@ class QueryBuilderTest extends TestCase
     public function it_executes_query_from_params()
     {
         $params = [
-            'filter' => ['name' => 'test']
+            'filter' => ['name' => 'test'],
         ];
 
         $queryBuilder = QueryBuilder::for(TestModel::class, null, $params)

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -3,13 +3,13 @@
 namespace Spatie\QueryBuilder\Tests;
 
 use Illuminate\Http\Request;
+use Spatie\QueryBuilder\Filter;
 use Spatie\QueryBuilder\Sorts\Sort;
 use Spatie\QueryBuilder\QueryBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Tests\Models\TestModel;
 use Spatie\QueryBuilder\Tests\Models\ScopeModel;
 use Spatie\QueryBuilder\Tests\Models\SoftDeleteModel;
-use Spatie\QueryBuilder\Filter;
 
 class QueryBuilderTest extends TestCase
 {


### PR DESCRIPTION
If you have a command line, there is no request for which it is not possible to use QueryBuilder.

Then a query by parameters may be required

Example use:

```
use App\User;
use Spatie\QueryBuilder\QueryBuilder;

clsss UserRepository
{
    protected $allowedFilter = ['name'];

    public function search(array $params = [])
    {
        // $params => ['name' => 'test']
        return QueryBuilder::for(User::class, null, ['filter' => $params])
            ->allowedFilters($this->allowedFilter)
            ->get();

        // $params => ['filter' => ['name' => 'test']]
        // return QueryBuilder::for(User::class, null, $params)
            ->allowedFilters($this->allowedFilter)
            ->get();
    }
}
`` 