### PR TITLE
Eliminates empty value on partial match filter

### DIFF
--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -16,9 +16,9 @@ class FiltersPartial extends FiltersExact implements Filter
 
         $sql = "LOWER({$wrappedProperty}) LIKE ?";
 
-        if (is_array($value)) {
+        if (is_array($value) && count(array_filter($value))) {
             return $query->where(function (Builder $query) use ($value, $sql) {
-                foreach ($value as $partialValue) {
+                foreach (array_filter($value) as $partialValue) {
                     $partialValue = mb_strtolower($partialValue, 'UTF8');
 
                     $query->orWhereRaw($sql, ["%{$partialValue}%"]);


### PR DESCRIPTION
Fixes issue where `/api/resource?filter[status]=1,2,3,` would return everything because of the trailing comma.  A partial match on empty value does not make sense and should be avoided.

It would be wise to of course eliminate the trailing comma when making the request, but just in case where it does get added, this fix eliminates unexpected results.