### PR TITLE
Adds chunk method to query builder to parse sorts

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -101,6 +101,13 @@ class QueryBuilder extends Builder
         return parent::simplePaginate($perPage, $columns, $pageName, $page);
     }
 
+    public function chunk($count, callable $callback)
+    {
+        $this->parseSorts();
+
+        return parent::chunk($count, $callback);
+    }
+
     /**
      * Add the model, scopes, eager loaded relationships, local macro's and onDelete callback
      * from the $builder to this query builder.

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -110,6 +110,18 @@ class SortTest extends TestCase
     }
 
     /** @test */
+    public function it_can_sort_a_chunk_query()
+    {
+        $this
+            ->createQueryFromSortRequest('-name')
+            ->chunk(100, function ($models) {
+                //
+            });
+
+        $this->assertQueryExecuted('select * from "test_models" order by "name" desc limit 100 offset 0');
+    }
+
+    /** @test */
     public function it_can_guard_against_sorts_that_are_not_allowed()
     {
         $sortedModels = $this


### PR DESCRIPTION
Since 1.17.3 version, when @AlexVanderbist fix duplication of sorts, if you use "chunk" method con query builder, the default sort doesn't affect because the chunk funcion use the enforceOrderBy function before get on queryBuilder and the parseSorts is not executed, so the default model sort is applied (id).

This PR adds the chunk function to ensure parse sorts before enforceOrderBy method is executed on chunk queries.