### PR TITLE
Align type-hint for for method with __construct.

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -33,7 +33,7 @@ class QueryBuilder extends Builder
     /**
      * Create a new QueryBuilder for a request and model.
      *
-     * @param string|\Illuminate\Database\Query\Builder $baseQuery Model class or base query builder
+     * @param string|\Illuminate\Database\Eloquent\Builder $baseQuery Model class or base query builder
      * @param \Illuminate\Http\Request                  $request
      *
      * @return \Spatie\QueryBuilder\QueryBuilder


### PR DESCRIPTION
Currently the `__construct` method type hints a `Illuminate\Database\Eloquent\Builder $builder`, but the static `for` method has a `\Illuminate\Database\Query\Builder` in its PHPDoc, that passes it to the `__construct()`. 

I've changed the Phpdoc of `for` to match the \Illuminate\Database\Eloquent\Builder used in `__construct()`. Now Phpstan seems satisfied and everything still works when I try it.