### PR TITLE
Updated pagination.md

### DIFF
--- a/docs/advanced-usage/pagination.md
+++ b/docs/advanced-usage/pagination.md
@@ -6,3 +6,14 @@ weight: 2
 This package doesn't provide any methods to help you paginate responses. However as documented above you can use Laravel's default [`paginate()` method](https://laravel.com/docs/5.5/pagination).
 
 If you want to completely adhere to the JSON API specification you can also use our own [spatie/json-api-paginate](https://github.com/spatie/laravel-json-api-paginate)!
+
+## Adding Paramaters to Pagination
+
+By default the query paramaters wont be added to the pagination json. You can append the request query to the pagination json by using the `appends` method available on the [LengthAwarePaginator](https://laravel.com/api/6.x/Illuminate/Contracts/Pagination/LengthAwarePaginator.html#method_appends).
+
+```php
+$users = QueryBuilder::for(User::class)
+    ->allowedFilters(['name', 'email'])
+    ->paginate()
+    ->appends(request()->query());
+```


### PR DESCRIPTION
By default the ->paginate() method does not pick up the parameters from Spatie Query builder. By using the appends method and grabbing the request query, you can add the parameters to the first_page_url, last_page_url, and next_page_url of the returned pagination JSON.