### PR TITLE
Added support for nested array filtering

### DIFF
--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\QueryBuilder;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\Filters\Filter;
 use Spatie\QueryBuilder\Filters\FiltersExact;
@@ -122,7 +123,11 @@ class AllowedFilter
     protected function resolveValueForFiltering($value)
     {
         if (is_array($value)) {
-            $remainingProperties = array_diff($value, $this->ignored->toArray());
+            $isMultidimensional = count($value) !== count($value, COUNT_RECURSIVE);
+
+            $remainingProperties = $isMultidimensional
+                ? Arr::except($value, $this->ignored->toArray())
+                : array_diff($value, $this->ignored->toArray());
 
             return ! empty($remainingProperties) ? $remainingProperties : null;
         }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -459,14 +459,14 @@ class FilterTest extends TestCase
         $filterClass = new class implements FilterInterface {
             public function __invoke(Builder $query, $value, string $property) : Builder
             {
-                 return $query->whereHas('relatedThroughPivotModels', function(Builder $query) use ($value) {
-                     $query->where(function(Builder $query) use ($value) {
-                         foreach ($value as $id => $names) {
-                             $query->orWhere(function (Builder $query) use ($id, $names) {
-                                 $query->where('related_through_pivot_models.id', $id)->whereIn('pivot_models.name', $names);
-                             });
-                         }
-                     });
+                return $query->whereHas('relatedThroughPivotModels', function (Builder $query) use ($value) {
+                    $query->where(function (Builder $query) use ($value) {
+                        foreach ($value as $id => $names) {
+                            $query->orWhere(function (Builder $query) use ($id, $names) {
+                                $query->where('related_through_pivot_models.id', $id)->whereIn('pivot_models.name', $names);
+                            });
+                        }
+                    });
                 });
             }
         };
@@ -474,7 +474,7 @@ class FilterTest extends TestCase
         $modelResult = $this
             ->createQueryFromFilterRequest([
                 'related' => [
-                    $relatedTestModel->id => 'John,Jane'
+                    $relatedTestModel->id => 'John,Jane',
                 ],
             ])
             ->allowedFilters(AllowedFilter::custom('related', $filterClass))
@@ -496,7 +496,7 @@ class FilterTest extends TestCase
         $models = $this
             ->createQueryFromFilterRequest([
                 'related' => [
-                    'abc' => 'John,Jane'
+                    'abc' => 'John,Jane',
                 ],
             ])
             ->allowedFilters(AllowedFilter::custom('related', $filterClass)->ignore('abc'))

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -62,6 +62,7 @@ class TestCase extends Orchestra
             $table->increments('id');
             $table->string('test_model_id');
             $table->integer('related_through_pivot_model_id');
+            $table->string('name')->nullable();
         });
 
         $app['db']->connection()->getSchemaBuilder()->create('related_through_pivot_models', function (Blueprint $table) {


### PR DESCRIPTION
I've added two tests to check that filter's value can be a multidimensional array and changed the value filtering function.

`array_diff()` function fails on multidimensional array because it cast the value to string, so in that case I think that we should run diff on array keys instead of values with `Arr::except()`