### PR TITLE
Split comma separated filter values on unspaced commas only (fixes #229)

### DIFF
--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -123,7 +123,7 @@ class QueryBuilderRequest extends Request
     private function explodeIgnoringWhitespace(string $delimiter, string $string): array
     {
         return preg_split(
-            '/' . preg_quote($delimiter) . '(?=\S)/',
+            '/'.preg_quote($delimiter).'(?=\S)/',
             trim($string, $delimiter),
             null,
             PREG_SPLIT_NO_EMPTY

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -100,7 +100,7 @@ class QueryBuilderRequest extends Request
         }
 
         if (Str::contains($value, ',')) {
-            return explode(',', $value);
+            return $this->explodeIgnoringWhitespace(',', $value);
         }
 
         if ($value === 'true') {
@@ -112,5 +112,21 @@ class QueryBuilderRequest extends Request
         }
 
         return $value;
+    }
+
+    /**
+     * @param string $delimiter The boundary string.
+     * @param string $string The input string
+     *
+     * @return array The values between the delimiters in the given string, ignoring any spaced delimiters inside values
+     */
+    private function explodeIgnoringWhitespace(string $delimiter, string $string): array
+    {
+        return preg_split(
+            '/' . preg_quote($delimiter) . '(?=\S)/',
+            trim($string, $delimiter),
+            null,
+            PREG_SPLIT_NO_EMPTY
+        );
     }
 }

--- a/tests/QueryBuilderRequestTest.php
+++ b/tests/QueryBuilderRequestTest.php
@@ -262,6 +262,20 @@ class QueryBuilderRequestTest extends TestCase
     }
 
     /** @test */
+    public function it_will_map_comma_separated_values_containing_commas_as_arrays()
+    {
+        $request = new QueryBuilderRequest([
+            'filter' => [
+                'foo' => 'bar, baz,qux',
+            ],
+        ]);
+
+        $expected = ['foo' => ['bar, baz', 'qux']];
+
+        $this->assertEquals($expected, $request->filters()->toArray());
+    }
+
+    /** @test */
     public function it_can_get_the_include_query_params_from_the_request()
     {
         $request = new QueryBuilderRequest([


### PR DESCRIPTION
Fixes most common cases of https://github.com/spatie/laravel-query-builder/issues/229
Commas used in values will usually have space around them so here we only treat commas without space around them as delimiters.

Old:
Filter value: `'Antwerpen, BE,Rotterdam, NL'`
Result: `['Antwerpen', ' BE', 'Rotterdam', ' NL']`

New:
Filter value: `'Antwerpen, BE,Rotterdam, NL'`
Result: `['Antwerpen, BE', 'Rotterdam, NL']`

Note: Using commas as delimiter hard-coded was left in-place, could be a new PR as suggested in linked issue.