### PR TITLE
Raise composer dependency level to fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/database": "~5.6.34|~5.7.0|~5.8.0|^6.0",
-        "illuminate/http": "~5.6.34|~5.7.0|~5.8.0|^6.0",
-        "illuminate/support": "~5.6.34|~5.7.0|~5.8.0|^6.0"
+        "illuminate/database": "~5.8.0|^6.0",
+        "illuminate/http": "~5.8.0|^6.0",
+        "illuminate/support": "~5.8.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0|^8.0",
-        "orchestra/testbench": "~3.6.0|~3.7.0|~3.8.0|^4.0",
+        "orchestra/testbench": "~3.8.0|^4.0",
         "ext-json": "*"
     },
     "autoload": {


### PR DESCRIPTION
Currently, when installing the minimal required dependencies and running the test suite, failures will occur.

`$ composer update --prefer-lowest && composer test`
<details><summary>Test result</summary>
<p>

```bash


PHPUnit 7.0.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.10
Configuration: /Users/dominik/code/laravel-query-builder/phpunit.xml.dist

............E..................................................  63 / 149 ( 42%)
........................................II........EE......E.... 126 / 149 ( 84%)
.......................                                         149 / 149 (100%)

Time: 10.83 seconds, Memory: 6.00MB

There were 4 errors:

1) Spatie\QueryBuilder\Tests\FieldsTest::it_can_fetch_sketchy_columns_if_they_are_allowed_fields
RuntimeException: This database engine does not support JSON operations.

/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:932
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:918
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Grammar.php:129
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:133
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:87
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:62
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php:49
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1914
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:1283
/Users/dominik/code/laravel-query-builder/tests/FieldsTest.php:81

2) Spatie\QueryBuilder\Tests\RelationFilterTest::it_can_disable_exact_filtering_based_on_related_model_properties
Error: Call to undefined method Spatie\QueryBuilder\Tests\RelationFilterTest::assertStringContainsString()

/Users/dominik/code/laravel-query-builder/tests/RelationFilterTest.php:154

3) Spatie\QueryBuilder\Tests\RelationFilterTest::it_can_disable_partial_filtering_based_on_related_model_properties
Error: Call to undefined method Spatie\QueryBuilder\Tests\RelationFilterTest::assertStringContainsString()

/Users/dominik/code/laravel-query-builder/tests/RelationFilterTest.php:169

4) Spatie\QueryBuilder\Tests\SortTest::it_can_sort_by_json_property_if_its_an_allowed_sort
RuntimeException: This database engine does not support JSON operations.

/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:932
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:918
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:626
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:624
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:609
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:87
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php:62
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php:49
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1914
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1963
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1951
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:2435
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1952
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:481
/Users/dominik/code/laravel-query-builder/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:465
/Users/dominik/code/laravel-query-builder/src/QueryBuilder.php:64
/Users/dominik/code/laravel-query-builder/tests/SortTest.php:113

--

There were 2 incomplete tests:

1) Spatie\QueryBuilder\Tests\QueryBuilderTest::it_can_get_a_query_from_a_relationship
This test proves that there's something wrong with Eloquent's getQuery()

/Users/dominik/code/laravel-query-builder/tests/QueryBuilderTest.php:175

2) Spatie\QueryBuilder\Tests\QueryBuilderTest::it_queries_the_correct_data_for_a_relationship_query
Currently broken due to Eloquent. See the above test.

/Users/dominik/code/laravel-query-builder/tests/QueryBuilderTest.php:198

ERRORS!
Tests: 149, Assertions: 192, Errors: 4, Incomplete: 2.
```

</p>
</details>

I raised the minimal requirements to include the new features used:

`$ composer install --prefer-lowest && composer test`

<details><summary>Success!</summary>
<p>

```bash

PHPUnit 7.5.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.10
Configuration: /Users/dominik/code/laravel-query-builder/phpunit.xml.dist

...............................................................  63 / 149 ( 42%)
........................................II..................... 126 / 149 ( 84%)
.......................                                         149 / 149 (100%)

Time: 12.04 seconds, Memory: 6.00MB

There were 2 incomplete tests:

1) Spatie\QueryBuilder\Tests\QueryBuilderTest::it_can_get_a_query_from_a_relationship
This test proves that there's something wrong with Eloquent's getQuery()

/Users/dominik/code/laravel-query-builder/tests/QueryBuilderTest.php:175

2) Spatie\QueryBuilder\Tests\QueryBuilderTest::it_queries_the_correct_data_for_a_relationship_query
Currently broken due to Eloquent. See the above test.

/Users/dominik/code/laravel-query-builder/tests/QueryBuilderTest.php:198

OK, but incomplete, skipped, or risky tests!
Tests: 149, Assertions: 196, Incomplete: 2.
```

</p>
</details>