### PR TITLE
use array_values so params are still passed to scope

### DIFF
--- a/src/Filters/FiltersScope.php
+++ b/src/Filters/FiltersScope.php
@@ -14,6 +14,6 @@ class FiltersScope implements Filter
 
         $values = Arr::wrap($values);
 
-        $query->$scope(...$values);
+        $query->$scope(...array_values($values));
     }
 }


### PR DESCRIPTION
Currently any filters that are using associative keys cannot be passed to the scope using the splat operator.

## Scenario
suppose I have this scope on my model:
```
public function scopePublishedBetween($query, $start, $end)
    {
        return $query
            ->where('published_at', '>=', Carbon::parse($start))
            ->where('published_at', '<=', Carbon::parse($end));
    }
```

And I've allowed this scope in my query:
```
AllowedFilter::scope('published_between')
```

Now I pass my date range as an associative array in the request like so:
```
let params = {
    filter: {
        start: '2019-11-20',
        end: '2019-11-25',
    },
};
```

When the query builder executes this request I receive this error because the splat operator does not support unpacking associative arrays.
```
Symfony\Component\Debug\Exception\FatalThrowableError
Cannot unpack array with string keys
```