### PR TITLE
Handle empty or null includes in allowed includes array

### DIFF
--- a/src/Concerns/AddsIncludesToQuery.php
+++ b/src/Concerns/AddsIncludesToQuery.php
@@ -18,6 +18,9 @@ trait AddsIncludesToQuery
         $includes = is_array($includes) ? $includes : func_get_args();
 
         $this->allowedIncludes = collect($includes)
+            ->filter(function ($include) {
+                return !empty($include);
+            })
             ->flatMap(function ($include): Collection {
                 if ($include instanceof IncludeInterface) {
                     return collect([$include]);

--- a/src/Concerns/AddsIncludesToQuery.php
+++ b/src/Concerns/AddsIncludesToQuery.php
@@ -18,8 +18,8 @@ trait AddsIncludesToQuery
         $includes = is_array($includes) ? $includes : func_get_args();
 
         $this->allowedIncludes = collect($includes)
-            ->filter(function ($include) {
-                return !empty($include);
+            ->reject(function ($include) {
+                return empty($include);
             })
             ->flatMap(function ($include): Collection {
                 if ($include instanceof IncludeInterface) {

--- a/src/Exceptions/InvalidIncludeQuery.php
+++ b/src/Exceptions/InvalidIncludeQuery.php
@@ -19,8 +19,15 @@ class InvalidIncludeQuery extends InvalidQuery
         $this->allowedIncludes = $allowedIncludes;
 
         $unknownIncludes = $unknownIncludes->implode(', ');
-        $allowedIncludes = $allowedIncludes->implode(', ');
-        $message = "Requested include(s) `{$unknownIncludes}` are not allowed. Allowed include(s) are `{$allowedIncludes}`.";
+
+        $message = "Requested include(s) `{$unknownIncludes}` are not allowed. ";
+
+        if ($allowedIncludes->count()) {
+            $allowedIncludes = $allowedIncludes->implode(', ');
+            $message .= "Allowed include(s) are `{$allowedIncludes}`.";
+        } else {
+            $message .= 'There are no allowed includes.';
+        }
 
         parent::__construct(Response::HTTP_BAD_REQUEST, $message);
     }

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -49,6 +49,20 @@ class IncludeTest extends TestCase
     }
 
     /** @test */
+    public function it_can_handle_empty_includes()
+    {
+        $models = QueryBuilder::for(TestModel::class, new Request())
+            ->allowedIncludes([
+                null,
+                [],
+                ''
+            ])
+            ->get();
+
+        $this->assertCount(TestModel::count(), $models);
+    }
+    
+    /** @test */
     public function it_can_include_model_relations()
     {
         $models = $this

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -56,12 +56,12 @@ class IncludeTest extends TestCase
                 null,
                 [],
                 ''
-            ])
+            ]),
             ->get();
 
         $this->assertCount(TestModel::count(), $models);
     }
-    
+
     /** @test */
     public function it_can_include_model_relations()
     {


### PR DESCRIPTION
Allows the `allowedIncludes()`method to be a bit more flexible and improves on the Exception language if no includes exist at all for a query.