### PR TITLE
Fix some AllowedSort docblocks

### DIFF
--- a/src/AllowedSort.php
+++ b/src/AllowedSort.php
@@ -8,10 +8,10 @@ use Spatie\QueryBuilder\Sorts\SortsField;
 
 class AllowedSort
 {
-    /** @var string */
+    /** @var \Spatie\QueryBuilder\Sorts\Sort */
     protected $sortClass;
 
-    /** @var \Spatie\QueryBuilder\Sorts\Sort */
+    /** @var string */
     protected $name;
 
     /** @var string */


### PR DESCRIPTION
These two docblocks were the wrong way around, each referencing the type the other should've.