### PR TITLE
Fix associative array on filtered properties

### DIFF
--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -134,7 +134,7 @@ class AllowedFilter
     protected function resolveValueForFiltering($value)
     {
         if (is_array($value)) {
-            $remainingProperties = array_diff($value, $this->ignored->toArray());
+            $remainingProperties = array_diff_assoc($value, $this->ignored->toArray());
 
             return ! empty($remainingProperties) ? $remainingProperties : null;
         }


### PR DESCRIPTION
## Description

On some projects, we need to filter models by json field and we perform the next request:

`...?filter[field][key][key]=search_value`

and applies a custom filter to search on database json fields.

With PHP < 7.4 it works, but with the update to 7.4 version it throws an error (`ErrorException : Array to string conversion`) because if you want to compare two associative arrays (like that) you must use the `array_diff_assoc` method instead of the basic `array_diff`. On other versions don't throw this error.

## Versions

It's happening on these versions:

- Spatie Query Builder 2.8.2
- PHP 7.4

## Solution

Change the `array_diff` method to `array_diff_assoc`. It performs the same comparation but works also with associative arrays.