### PR TITLE
Filter method with standard eloquent builder

### DIFF
--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\QueryBuilder;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\Filters\Filter;
 use Spatie\QueryBuilder\Filters\FiltersCallback;
@@ -38,7 +39,7 @@ class AllowedFilter
         $this->internalName = $internalName ?? $name;
     }
 
-    public function filter(QueryBuilder $query, $value)
+    public function filter(Builder $query, $value)
     {
         $valueToFilter = $this->resolveValueForFiltering($value);
 


### PR DESCRIPTION
This PR enables the option to use the filters from a standard laravel query if you want to use the allowedfilters outside from the Spatie Query Builder.

It has no reason to use on this method the QueryBuilder instead of standard Builder (on filter interface uses the eloquent builder)