### PR TITLE
add ability to filter by nested relation scopes

### DIFF
--- a/src/Filters/FiltersScope.php
+++ b/src/Filters/FiltersScope.php
@@ -14,10 +14,20 @@ class FiltersScope implements Filter
 {
     public function __invoke(Builder $query, $values, string $property): Builder
     {
-        $scope = Str::camel($property);
+        $propertyParts = Str::of($property)->explode('.');
+
+        $scope = Str::camel($propertyParts->pop());
 
         $values = array_values(Arr::wrap($values));
         $values = $this->resolveParameters($query, $values, $scope);
+
+        $relation = $propertyParts->implode('.');
+
+        if ($relation) {
+            return $query->whereHas($relation, function (Builder $query) use ($scope, $values) {
+                return $query->$scope(...$values);
+            });
+        }
 
         return $query->$scope(...$values);
     }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -201,6 +201,21 @@ class FilterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_filter_results_by_nested_relation_scope()
+    {
+        $testModel = TestModel::create(['name' => 'John Testing Doe']);
+
+        $testModel->relatedModels()->create(['name' => 'John\'s Post']);
+
+        $modelsResult = $this
+            ->createQueryFromFilterRequest(['relatedModels.named' => 'John\'s Post'])
+            ->allowedFilters(AllowedFilter::scope('relatedModels.named'))
+            ->get();
+
+        $this->assertCount(1, $modelsResult);
+    }
+
+    /** @test */
     public function it_can_filter_results_by_type_hinted_scope()
     {
         TestModel::create(['name' => 'John Testing Doe']);

--- a/tests/TestClasses/Models/RelatedModel.php
+++ b/tests/TestClasses/Models/RelatedModel.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\QueryBuilder\Tests\TestClasses\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -20,5 +21,10 @@ class RelatedModel extends Model
     public function nestedRelatedModels(): HasMany
     {
         return $this->hasMany(NestedRelatedModel::class);
+    }
+
+    public function scopeNamed(Builder $query, string $name): Builder
+    {
+        return $query->where('name', $name);
     }
 }


### PR DESCRIPTION
// users/1?filter[posts.older_than]=2020-09-03
in english: filter users who have posts older than exact time.

the older than scope is placed in the Post Model
I use the Query Builder on the User Model and I wanted to filter them with a scope placed in the related posts.

`AllowedFilter::scope('posts.older_than)`