### PR TITLE
Adds Laravel 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "illuminate/database": "~5.6.34|~5.7.0|~5.8.0|^6.0|^7.0",
-        "illuminate/http": "~5.6.34|~5.7.0|~5.8.0|^6.0|^7.0",
-        "illuminate/support": "~5.6.34|~5.7.0|~5.8.0|^6.0|^7.0"
+        "php": "^7.3",
+        "illuminate/database": ">=5.6.34",
+        "illuminate/http": ">=5.6.34",
+        "illuminate/support": ">=5.6.34"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0|^8.0|^9.0",


### PR DESCRIPTION
In order to ensure compatibility with the next major version of Laravel, we'd have to bump the `illuminate/support` version.