### PR TITLE
Add config param to allow disable InvalidFilterQuery exception

### DIFF
--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -30,8 +30,8 @@ return [
     'count_suffix' => 'Count',
 
     /*
-     * By default the package will throw a InvalidFilterQuery exception when a filter in url is not set in
-     * allowedFilters method
+     * By default the package will throw an `InvalidFilterQuery` exception when a filter in the
+     * URL is not allowed in the `allowedFilters()` method.
      */
     'disable_invalid_filter_query_exception' => false,
 

--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -29,4 +29,10 @@ return [
      */
     'count_suffix' => 'Count',
 
+    /*
+     * By default the package will throw a InvalidFilterQuery exception when a filter in url is not set in
+     * allowedFilters method
+     */
+    'disable_invalid_filter_query_exception' => false,
+
 ];

--- a/docs/features/filtering.md
+++ b/docs/features/filtering.md
@@ -35,6 +35,17 @@ $users = QueryBuilder::for(User::class)
 
 Finally, when trying to filter on properties that have not been allowed using `allowedFilters()` an `InvalidFilterQuery` exception will be thrown along with a list of allowed filters.
 
+
+## Disable InvalidFilterQuery exception
+
+You can set in configuration file to not throw an InvalidFilterQuery exception when a filter is not set in allowedFilter method.
+
+```php
+'disable_invalid_filter_query_exception' => true
+```
+
+By default the option is set false.
+
 ## Exact filters
 
 When filtering IDs, boolean values or a literal string, you'll want to use exact filters. This way `/users?filter[id]=1` won't match all users having the digit `1` in their ID.

--- a/src/Concerns/FiltersQuery.php
+++ b/src/Concerns/FiltersQuery.php
@@ -70,7 +70,7 @@ trait FiltersQuery
 
         $diff = $filterNames->diff($allowedFilterNames);
 
-        if ($diff->count()) {
+        if ($diff->count() && ! config('query_builder.disable_invalid_filter_query_exception')) {
             throw InvalidFilterQuery::filtersNotAllowed($diff, $allowedFilterNames);
         }
     }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -341,6 +341,18 @@ class FilterTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_throw_invalid_filter_exception_when_disable_in_config()
+    {
+        config(['query_builder.disable_invalid_filter_query_exception' => true]);
+
+        $this
+            ->createQueryFromFilterRequest(['name' => 'John'])
+            ->allowedFilters('id');
+
+        $this->assertTrue(true);
+    }
+
+    /** @test */
     public function it_can_create_a_custom_filter_with_an_instantiated_filter()
     {
         $customFilter = new class('test1') implements CustomFilter {


### PR DESCRIPTION
Hi folks!

This PR implements a configuration parameter that allows disable the InvalidFilterQuery exception.

I think that I haven't seen an error message when changing the filter parameter in any site until see in mine.

Any suggestions are welcome! Thanks!

@freekmurze you already accepted a PR from me, in the dropbox package. If you would like to see this one, will be very great!