### PR TITLE
Add LengthAwarePaginator to QueryBuilder

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Spatie\QueryBuilder\Concerns\AddsFieldsToQuery;
@@ -111,6 +112,10 @@ class QueryBuilder implements ArrayAccess
 
         if ($result instanceof Collection) {
             $this->addAppendsToResults($result);
+        }
+
+        if ($result instanceof LengthAwarePaginator) {
+            $this->addAppendsToResults(collect($result->items()));
         }
 
         return $result;

--- a/tests/AppendTest.php
+++ b/tests/AppendTest.php
@@ -2,7 +2,10 @@
 
 namespace Spatie\QueryBuilder\Tests;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\Tests\TestClasses\Models\AppendModel;
@@ -51,23 +54,23 @@ class AppendTest extends TestCase
     /** @test */
     public function it_can_append_collections()
     {
-        $model = $this
+        $models = $this
             ->createQueryFromAppendRequest('FullName')
             ->allowedAppends('fullname')
             ->get();
 
-        $this->assertAttributeLoaded($model, 'fullname');
+        $this->assertCollectionAttributeLoaded($models, 'fullname');
     }
 
     /** @test */
     public function it_can_append_paginates()
     {
-        $model = $this
+        $models = $this
             ->createQueryFromAppendRequest('FullName')
             ->allowedAppends('fullname')
             ->paginate();
 
-        $this->assertAttributeLoaded($model, 'fullname');
+        $this->assertPaginateAttributeLoaded($models, 'fullname');
     }
 
     /** @test */
@@ -135,5 +138,25 @@ class AppendTest extends TestCase
     protected function assertAttributeLoaded(AppendModel $model, string $attribute)
     {
         $this->assertTrue(array_key_exists($attribute, $model->toArray()));
+    }
+
+    protected function assertCollectionAttributeLoaded(Collection $collection, string $attribute)
+    {
+        $hasModelWithoutAttributeLoaded = $collection
+            ->contains(function (Model $model) use ($attribute) {
+                return ! array_key_exists($attribute, $model->toArray());
+            });
+
+        $this->assertFalse($hasModelWithoutAttributeLoaded, "The `{$attribute}` attribute was expected but not loaded.");
+    }
+
+    protected function assertPaginateAttributeLoaded(LengthAwarePaginator $collection, string $attribute)
+    {
+        $hasModelWithoutAttributeLoaded = $collection
+            ->contains(function (Model $model) use ($attribute) {
+                return ! array_key_exists($attribute, $model->toArray());
+            });
+
+        $this->assertFalse($hasModelWithoutAttributeLoaded, "The `{$attribute}` attribute was expected but not loaded.");
     }
 }

--- a/tests/AppendTest.php
+++ b/tests/AppendTest.php
@@ -49,6 +49,28 @@ class AppendTest extends TestCase
     }
 
     /** @test */
+    public function it_can_append_collections()
+    {
+        $model = $this
+            ->createQueryFromAppendRequest('FullName')
+            ->allowedAppends('fullname')
+            ->get();
+
+        $this->assertAttributeLoaded($model, 'fullname');
+    }
+
+    /** @test */
+    public function it_can_append_paginates()
+    {
+        $model = $this
+            ->createQueryFromAppendRequest('FullName')
+            ->allowedAppends('fullname')
+            ->paginate();
+
+        $this->assertAttributeLoaded($model, 'fullname');
+    }
+
+    /** @test */
     public function it_guards_against_invalid_appends()
     {
         $this->expectException(InvalidAppendQuery::class);


### PR DESCRIPTION
When using `->paginate()` or `->jsonPaginate()`, it seems it doesn't inject the appends when needed.
This should fix #531.

This does work, but please let me know if the code can improved. :)