### PR TITLE
Update what defines an ignored filter value

### DIFF
--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -21,12 +21,12 @@ class FiltersPartial extends FiltersExact implements Filter
         $sql = "LOWER({$wrappedProperty}) LIKE ?";
 
         if (is_array($value)) {
-            if (count(array_filter($value)) === 0) {
+            if (count(array_filter($value, 'strlen')) === 0) {
                 return $query;
             }
 
             $query->where(function (Builder $query) use ($value, $sql) {
-                foreach (array_filter($value) as $partialValue) {
+                foreach (array_filter($value, 'strlen') as $partialValue) {
                     $partialValue = mb_strtolower($partialValue, 'UTF8');
 
                     $query->orWhereRaw($sql, ["%{$partialValue}%"]);

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -155,6 +155,21 @@ class FilterTest extends TestCase
     }
 
     /** @test */
+    public function falsy_values_are_not_ignored_when_applying_a_partial_filter()
+    {
+        DB::enableQueryLog();
+
+        $this
+            ->createQueryFromFilterRequest([
+                'id' => [0],
+            ])
+            ->allowedFilters(AllowedFilter::partial('id'))
+            ->get();
+
+        $this->assertQueryLogContains("select * from `test_models` where (LOWER(`id`) LIKE ?)");
+    }
+
+    /** @test */
     public function it_can_filter_and_match_results_by_exact_property()
     {
         $testModel = TestModel::first();


### PR DESCRIPTION
Fixes #495 

As suggested the issue the addition of the `strlen` callback allows for falsy values (most often '0') to stay and only filter truly empty strings, like originally intended when this feature was implemented. (https://github.com/spatie/laravel-query-builder/commit/f7fd9a470890898f2814cf929a90e4770ea2d2c4)