### PR TITLE
Remove untested and undocumented snake-casing of filter fields

### DIFF
--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -73,8 +73,6 @@ trait AddsFieldsToQuery
             ->map(function ($fields, $model) {
                 $tableName = Str::snake(preg_replace('/-/', '_', $model));
 
-                $fields = array_map([Str::class, 'snake'], $fields);
-
                 return $this->prependFieldsWithTableName($fields, $tableName);
             })
             ->flatten()


### PR DESCRIPTION
Fixes #524 

> > It seems that's a similar problem that occurs in [#515](https://github.com/spatie/laravel-query-builder/issues/515#issuecomment-689229711).
> 
> It's a really annoying feature. IMO `ensureAllFieldsExist` can be safely deleted.
> 
> To use this package I've had to wrap the `QueryBuilder` and override the `allowedFilters` method and comment out the line where it issues `$this->ensureAllFiltersExist();`

I think `ensureAllFieldsExist` is actually quite helpful and is not actually the problem for this issue.
The problem is the snake_casing of user-supplied parameters, as @marttosc already pointed out.

