### PR TITLE
Make nested scope compatible with older Laravel

### DIFF
--- a/src/Filters/FiltersScope.php
+++ b/src/Filters/FiltersScope.php
@@ -14,7 +14,7 @@ class FiltersScope implements Filter
 {
     public function __invoke(Builder $query, $values, string $property): Builder
     {
-        $propertyParts = Str::of($property)->explode('.');
+        $propertyParts = collect(explode('.', $property));
 
         $scope = Str::camel($propertyParts->pop());
 


### PR DESCRIPTION
Hi! this simple PR is a fix to:
```
BadMethodCallException: Method Illuminate\Support\Str::of does not exist.
```
Those who still use older version of Laravel (< 7) and upgraded the package from 3.2.4 to 3.3.0 might encounter this issue because the absent of Fluent String feature available starting from Laravel 7.