### PR TITLE
Multidimensional values run scope multiple times

### DIFF
--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -361,6 +361,24 @@ class FilterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_filter_by_scope_multiple_times()
+    {
+        Carbon::setTestNow(Carbon::parse('2016-05-05'));
+
+        $testModel = TestModel::create(['name' => 'John Testing Doe']);
+
+        $modelsResult = $this
+            ->createQueryFromFilterRequest(['created_between' => [
+                ['2016-01-01', '2017-01-01'],
+                ['2015-01-01', '2018-01-01'],
+            ]])
+            ->allowedFilters(AllowedFilter::scope('created_between'))
+            ->get();
+
+        $this->assertCount(1, $modelsResult);
+    }
+
+    /** @test */
     public function it_guards_against_invalid_filters()
     {
         $this->expectException(InvalidFilterQuery::class);


### PR DESCRIPTION
Fixes #530

Accept multidimensional values without crashing🔥 , use these values to run scope multiple times.
Before when a query such as `?filter[valueBetween][0]=2000,3000&filter[valueBetween][1]=3000,4000` was ran it would fail on "Array to string conversion" while checking for ignored values.

Now we jump deeper 🕳️  into the array to check if there are any ignored values.

If the values have been resolved we will run the scope however many times requested.

How the execution of the scope should be handled the second time should be defined in the scope.