### PR TITLE
Allow disabling of camel case conversion in relationship names

### DIFF
--- a/src/AllowedInclude.php
+++ b/src/AllowedInclude.php
@@ -26,9 +26,9 @@ class AllowedInclude
         $this->internalName = $internalName ?? $this->name;
     }
 
-    public static function relationship(string $name, ?string $internalName = null): Collection
+    public static function relationship(string $name, ?string $internalName = null, bool $camelCase = true): Collection
     {
-        $internalName = Str::camel($internalName ?? $name);
+        $internalName = $camelCase ? Str::camel($internalName ?? $name) : ($internalName ?? $name);
 
         return IncludedRelationship::getIndividualRelationshipPathsFromInclude($internalName)
             ->zip(IncludedRelationship::getIndividualRelationshipPathsFromInclude($name))

--- a/src/AllowedInclude.php
+++ b/src/AllowedInclude.php
@@ -19,9 +19,9 @@ class AllowedInclude
     /** @var string|null */
     protected $internalName;
 
-    public function __construct(string $name, IncludeInterface $includeClass, ?string $internalName = null)
+    public function __construct(string $name, IncludeInterface $includeClass, ?string $internalName = null, bool $camelCase = true)
     {
-        $this->name = Str::camel($name);
+        $this->name = $camelCase ? Str::camel($name) : $name;
         $this->includeClass = $includeClass;
         $this->internalName = $internalName ?? $this->name;
     }


### PR DESCRIPTION
Allow disabling of camel case conversion in relationship names

### Usage
QueryBuilder::for(Post::class)
            ->allowedIncludes([
                AllowedInclude::relationship('relationship_name', null, false),
            ])