### PR TITLE
Fix the defaultDirection example

### DIFF
--- a/docs/features/sorting.md
+++ b/docs/features/sorting.md
@@ -109,7 +109,7 @@ $customSort = AllowedSort::custom('custom-sort', new SentSort())->defaultDirecti
 
 $users = QueryBuilder::for(User::class)
             ->allowedSorts($customSort)
-            ->defaultSort($customSort)->defaultDirection(SortDirection::DESCENDING)
+            ->defaultSort($customSort->defaultDirection(SortDirection::DESCENDING))
             ->get();
 ```
 


### PR DESCRIPTION
In the third custom sorts example, `defaultDirection` is shown as chaining from `QueryBuilder`/`SortsQuery` but is actually a method on `AllowedSort`.