### PR TITLE
Allow to get params from $request->input

### DIFF
--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -35,4 +35,9 @@ return [
      */
     'disable_invalid_filter_query_exception' => false,
 
+    /*
+     * By default the package inspects query string of request - $request->query().
+     * You can change this behavior to $request->input() by setting this value to `true`.
+     */
+    'inspect_input_instead_of_query' => false,
 ];

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -36,10 +36,10 @@ class QueryBuilderRequest extends Request
     {
         $includeParameterName = config('query-builder.parameters.include');
 
-        $includeParts = $this->query($includeParameterName);
+        $includeParts = $this->getInput($includeParameterName);
 
         if (! is_array($includeParts)) {
-            $includeParts = explode(static::getIncludesArrayValueDelimiter(), $this->query($includeParameterName));
+            $includeParts = explode(static::getIncludesArrayValueDelimiter(), $this->getInput($includeParameterName));
         }
 
         return collect($includeParts)
@@ -51,7 +51,7 @@ class QueryBuilderRequest extends Request
     {
         $appendParameterName = config('query-builder.parameters.append');
 
-        $appendParts = $this->query($appendParameterName);
+        $appendParts = $this->getInput($appendParameterName);
 
         if (! is_array($appendParts)) {
             $appendParts = explode(static::getAppendsArrayValueDelimiter(), strtolower($appendParts));
@@ -64,7 +64,7 @@ class QueryBuilderRequest extends Request
     {
         $fieldsParameterName = config('query-builder.parameters.fields');
 
-        $fieldsPerTable = collect($this->query($fieldsParameterName));
+        $fieldsPerTable = collect($this->getInput($fieldsParameterName));
 
         if ($fieldsPerTable->isEmpty()) {
             return collect();
@@ -79,7 +79,7 @@ class QueryBuilderRequest extends Request
     {
         $sortParameterName = config('query-builder.parameters.sort');
 
-        $sortParts = $this->query($sortParameterName);
+        $sortParts = $this->getInput($sortParameterName);
 
         if (is_string($sortParts)) {
             $sortParts = explode(static::getSortsArrayValueDelimiter(), $sortParts);
@@ -92,7 +92,7 @@ class QueryBuilderRequest extends Request
     {
         $filterParameterName = config('query-builder.parameters.filter');
 
-        $filterParts = $this->query($filterParameterName, []);
+        $filterParts = $this->getInput($filterParameterName, []);
 
         if (is_string($filterParts)) {
             return collect();
@@ -131,6 +131,11 @@ class QueryBuilderRequest extends Request
         }
 
         return $value;
+    }
+
+    protected function getInput(?string $key = null, $default = null)
+    {
+        return config('query-builder.inspect_input_instead_of_query') ? $this->input($key, $default) : $this->query($key, $default);
     }
 
     public static function setIncludesArrayValueDelimiter(string $includesArrayValueDelimiter): void

--- a/tests/QueryBuilderRequestTest.php
+++ b/tests/QueryBuilderRequestTest.php
@@ -87,6 +87,18 @@ class QueryBuilderRequestTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_sort_query_param_from_the_request_body()
+    {
+        config(['query-builder.inspect_input_instead_of_query' => true]);
+
+        $request = new QueryBuilderRequest([], [
+            'sort' => 'foobar',
+        ], [], [], [], ['REQUEST_METHOD' => 'POST']);
+
+        $this->assertEquals(['foobar'], $request->sorts()->toArray());
+    }
+
+    /** @test */
     public function it_can_get_different_sort_query_parameter_name()
     {
         config(['query-builder.parameters.sort' => 'sorts']);
@@ -145,6 +157,26 @@ class QueryBuilderRequestTest extends TestCase
 
         $this->assertEquals($expected, $request->filters());
     }
+
+        /** @test */
+        public function it_can_get_the_filter_query_params_from_the_request_body()
+        {
+            config(['query-builder.inspect_input_instead_of_query' => true]);
+
+            $request = new QueryBuilderRequest([], [
+                'filter' => [
+                    'foo' => 'bar',
+                    'baz' => 'qux',
+                ],
+            ], [], [], [], ['REQUEST_METHOD' => 'POST']);
+
+            $expected = collect([
+                'foo' => 'bar',
+                'baz' => 'qux',
+            ]);
+
+            $this->assertEquals($expected, $request->filters());
+        }
 
     /** @test */
     public function it_can_get_different_filter_query_parameter_name()
@@ -274,6 +306,20 @@ class QueryBuilderRequestTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_the_include_from_the_request_body()
+    {
+        config(['query-builder.inspect_input_instead_of_query' => true]);
+
+        $request = new QueryBuilderRequest([], [
+            'include' => 'foo,bar',
+        ], [], [], [], ['REQUEST_METHOD' => 'POST']);
+
+        $expected = collect(['foo', 'bar']);
+
+        $this->assertEquals($expected, $request->includes());
+    }
+
+    /** @test */
     public function it_can_get_different_include_query_parameter_name()
     {
         config(['query-builder.parameters.include' => 'includes']);
@@ -305,6 +351,22 @@ class QueryBuilderRequestTest extends TestCase
                 'table' => 'name,email',
             ],
         ]);
+
+        $expected = collect(['table' => ['name', 'email']]);
+
+        $this->assertEquals($expected, $request->fields());
+    }
+
+    /** @test */
+    public function it_can_get_requested_fields_from_the_request_body()
+    {
+        config(['query-builder.inspect_input_instead_of_query' => true]);
+
+        $request = new QueryBuilderRequest([], [
+            'fields' => [
+                'table' => 'name,email',
+            ],
+        ], [], [], [], ['REQUEST_METHOD' => 'POST']);
 
         $expected = collect(['table' => ['name', 'email']]);
 
@@ -359,6 +421,20 @@ class QueryBuilderRequestTest extends TestCase
         $request = new QueryBuilderRequest();
 
         $expected = collect();
+
+        $this->assertEquals($expected, $request->appends());
+    }
+
+    /** @test */
+    public function it_can_get_the_append_query_params_from_the_request_body()
+    {
+        config(['query-builder.inspect_input_instead_of_query' => true]);
+
+        $request = new QueryBuilderRequest([], [
+            'append' => 'foo,bar',
+        ], [], [], [], ['REQUEST_METHOD' => 'POST']);
+
+        $expected = collect(['foo', 'bar']);
 
         $this->assertEquals($expected, $request->appends());
     }


### PR DESCRIPTION
Our Api Design Guide forces us to follow the following convention for search requests:
```
POST /api/v1/customers:search
{
   "include": ["addresses"],
   "sort": ["-created_at,"id"]
   ....
}
```
It makes some sense because we can avoid some limitations of get requests this way like "request string is too long"

`laravel-query-builder` can help us a lot, but there is a problem - it always gets datafrom $request->query() no matter of request method and we can't move those fields to query string due to Design Guide.

The current solutions that I'm aware of are not great.
1. Pass `new Request()` to *every* query builder call like that $query = QueryBuilder::for(Customer::class, new Request($request->all())) 
This seems hacky and not very convenient, especially if you call query builder in a scope without `$request` available

2. 
   - inherit `QueryBuilderRequest` (you actually need to copy paste the majority of it to the child class btw), 
   - replace `QueryBuilderRequest` binding in the service container with the new one.
   - inherit `QueryBuilder` itself because it still creates old `QueryBuilderRequest` due [this ](https://github.com/spatie/laravel-query-builder/blob/master/src/QueryBuilder.php#L45) and [that](https://github.com/spatie/laravel-query-builder/blob/master/src/QueryBuilder.php#L68)
  - start using the inherited QueryBuilder everywhere.
  Frankly, this looks extremely fragile. I'm not even sure it 100% works now, and I'm even less sure it won't break in the future package releases.

So, the idea is to add this kind of stuff to the package itself, especially since the issue was already raised before by some ppl, e.g #345

It does not seem to be a good idea to blindly change everything from $request->query() to $request->input() or smth else because it will definitely cause BC breaks.

That's why this PR introduces new `inspect_input_instead_of_query => false|true` configuration option

If the developer changes it to `true` the packages starts to seek `include`, `sort` e.t.c parameters in `$request->input()` instead of `$request->query()`