### PR TITLE
Custom AllowInclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $users = QueryBuilder::for(User::class)
 // all `User`s with their `posts` loaded
 ```
 
-[Read more about include features like: including nested relationships, including relationship count, ...](https://docs.spatie.be/laravel-query-builder/v3/features/including-relationships/)
+[Read more about include features like: including nested relationships, including relationship count, custom includes, ...](https://docs.spatie.be/laravel-query-builder/v3/features/including-relationships/)
 
 ### Sorting a query based on a request: `/users?sort=id`:
 

--- a/docs/features/including-relationships.md
+++ b/docs/features/including-relationships.md
@@ -110,7 +110,7 @@ class AggregateInclude implements IncludeInterface
 // GET /posts?include=comments_sum_votes
 
 $posts = QueryBuilder::for(Post::class)
-    ->allowedFilters([
+    ->allowedIncludes([
         AllowedInclude::custom('comments_sum_votes', new AggregateInclude('votes', 'sum'), 'comments'),
     ])
     ->get();

--- a/src/AllowedInclude.php
+++ b/src/AllowedInclude.php
@@ -59,6 +59,13 @@ class AllowedInclude
         ]);
     }
 
+    public static function custom(string $name, IncludeInterface $includeClass, ?string $internalName = null): Collection
+    {
+        return collect([
+            new static($name, $includeClass, $internalName),
+        ]);
+    }
+
     public function include(QueryBuilder $query): void
     {
         if (property_exists($this->includeClass, 'getRequestedFieldsForRelatedTable')) {


### PR DESCRIPTION
This pull request aims to add the option to define custom includes when none of the currently available methods fit.
The custom method accepts the include name, internal name and the custom include class.
This can be considered as a workaround to allow using Laravel 8's aggregate feature with all Laravel versions supported by the package.