### PR TITLE
Fix simple paginator append not working

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Spatie\QueryBuilder\Concerns\AddsFieldsToQuery;
@@ -124,18 +125,18 @@ class QueryBuilder implements ArrayAccess
             $this->addAppendsToResults($result);
         }
 
-        if ($result instanceof LengthAwarePaginator) {
+        if ($result instanceof LengthAwarePaginator || $result instanceof Paginator) {
             $this->addAppendsToResults(collect($result->items()));
         }
 
         return $result;
     }
-    
+
     public function clone()
     {
         return clone $this;
     }
-    
+
     public function __clone()
     {
         $this->subject = clone $this->subject;

--- a/tests/AppendTest.php
+++ b/tests/AppendTest.php
@@ -5,6 +5,7 @@ namespace Spatie\QueryBuilder\Tests;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\Exceptions\InvalidAppendQuery;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -151,6 +152,16 @@ class AppendTest extends TestCase
     }
 
     protected function assertPaginateAttributeLoaded(LengthAwarePaginator $collection, string $attribute)
+    {
+        $hasModelWithoutAttributeLoaded = $collection
+            ->contains(function (Model $model) use ($attribute) {
+                return ! array_key_exists($attribute, $model->toArray());
+            });
+
+        $this->assertFalse($hasModelWithoutAttributeLoaded, "The `{$attribute}` attribute was expected but not loaded.");
+    }
+
+    protected function assertSimplePaginateAttributeLoaded(Paginator $collection, string $attribute)
     {
         $hasModelWithoutAttributeLoaded = $collection
             ->contains(function (Model $model) use ($attribute) {


### PR DESCRIPTION
Laravel offers more pagination like the newly introduced cursor. I didn't test that one, but may be interested to add as well. :)

For now this should fix when someone uses a simple paginate which is not length aware #632 .