### PR TITLE
fix unexpected lowecasing of appends

### DIFF
--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -54,7 +54,7 @@ class QueryBuilderRequest extends Request
         $appendParts = $this->getRequestData($appendParameterName);
 
         if (! is_array($appendParts)) {
-            $appendParts = explode(static::getAppendsArrayValueDelimiter(), strtolower($appendParts));
+            $appendParts = explode(static::getAppendsArrayValueDelimiter(), $appendParts);
         }
 
         return collect($appendParts)->filter();

--- a/tests/QueryBuilderRequestTest.php
+++ b/tests/QueryBuilderRequestTest.php
@@ -454,4 +454,16 @@ class QueryBuilderRequestTest extends TestCase
 
         $this->assertEquals($expected, $request->filters()->toArray());
     }
+
+    /** @test */
+    public function it_adds_any_appends_as_they_come_from_the_request()
+    {
+        $request = new QueryBuilderRequest([
+            'append' => 'aCamelCaseAppend,anotherappend',
+        ]);
+
+        $expected = collect(['aCamelCaseAppend', 'anotherappend']);
+
+        $this->assertEquals($expected, $request->appends());
+    }
 }


### PR DESCRIPTION
Appends from the request get lowercased which results in non-matching request appends and allowedAppends.

i.e. `allowedAppends('someComelCaseAppend')`
`/api-url/endpoint?append=someComelCaseAppend`

This causes the request parameter append with value `someComelCaseAppend` to become `somecamelcaseappend` which is not the expected behaviour. 