### PR TITLE
Use exact relationship provided by developer

### DIFF
--- a/src/Filters/FiltersExact.php
+++ b/src/Filters/FiltersExact.php
@@ -48,7 +48,7 @@ class FiltersExact implements Filter
             return false;
         }
 
-        $firstRelationship = Str::camel(explode('.', $property)[0]);
+        $firstRelationship = explode('.', $property)[0];
 
         if (! method_exists($query->getModel(), $firstRelationship)) {
             return false;


### PR DESCRIPTION
Changing the relationship method name provided by the developer to camel case is bad practice. This is also undocumented and unexpected behavior and quite frustrating as a developer using this package. The name of the filter is exact - it should be _exact_.