### PR TITLE
Remove todo & add deferred to service provider

### DIFF
--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -2,9 +2,10 @@
 
 namespace Spatie\QueryBuilder;
 
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 
-class QueryBuilderServiceProvider extends ServiceProvider
+class QueryBuilderServiceProvider extends ServiceProvider implements DeferrableProvider
 {
     public function boot()
     {
@@ -26,8 +27,6 @@ class QueryBuilderServiceProvider extends ServiceProvider
 
     public function provides()
     {
-        // TODO: implement DeferrableProvider when Laravel 5.7 support is dropped.
-
         return [
             QueryBuilderRequest::class,
         ];


### PR DESCRIPTION
I think this package already dropped Laravel 5 compatibility (also this version isn't LTS/supported anymore)

So I just added the deferrable interface as mentioned in the todo, tests remain the same (no extra failures or errors)