### PR TITLE
Allows for selecting fields of related models with custom names

### DIFF
--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -50,11 +50,11 @@ trait AddsFieldsToQuery
 
     public function getRequestedFieldsForRelatedTable(string $relation): array
     {
-        $table = Str::plural(Str::snake($relation)); // TODO: make this configurable
+        $table = (new ($this->getModel()))->$relation()->getRelated()->getTable();
 
         $fields = $this->request->fields()->mapWithKeys(function ($fields, $table) {
             return [$table => $fields];
-        })->get($table);
+        })->get($relation);
 
         if (! $fields) {
             return [];


### PR DESCRIPTION
This allows for a relationship to be defined which varies from the underlying table and does not require the user to know the underlying table name.

For example relation of user() but uses a table of private_users would fail in the old paradigm.