### PR TITLE
PHP 8.1 Support

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -153,21 +153,25 @@ class QueryBuilder implements ArrayAccess
         $this->subject->{$name} = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->subject[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->subject[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->subject[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->subject[$offset]);

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -153,26 +153,22 @@ class QueryBuilder implements ArrayAccess
         $this->subject->{$name} = $value;
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->subject[$offset]);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): bool
     {
         return $this->subject[$offset];
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->subject[$offset] = $value;
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->subject[$offset]);
     }

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -51,7 +51,7 @@ class QueryBuilderRequest extends Request
 
         $appendParts = $this->getRequestData($appendParameterName);
 
-        if (! is_array($appendParts)) {
+        if (! is_array($appendParts) && ! is_null($appendParts)) {
             $appendParts = explode(static::getAppendsArrayValueDelimiter(), $appendParts);
         }
 


### PR DESCRIPTION
Trying out this package on PHP 8.1 fails with `During inheritance of ArrayAccess: Uncaught ErrorException: Return type of Spatie\QueryBuilder\QueryBuilder::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/vendor/spatie/laravel-query-builder/src/QueryBuilder.php:168`

This PR addresses the issue by adding `#[\ReturnTypeWillChange]` to the offset methods.

I also ran into an issue with null being passed to explode: `explode(): Passing null to parameter #2 ($string) of type string is deprecated {"exception":"[object] (ErrorException(code: 0): explode(): Passing null to parameter #2 ($string) of type string is deprecated at /app/vendor/spatie/laravel-query-builder/src/QueryBuilderRequest.php:55)`

I fixed it by adding an extra null check:

https://github.com/Medalink/laravel-query-builder/blob/67ad6d786f34717a14b5d5fcc77735c86a18bfa9/src/QueryBuilderRequest.php#L54-L56