### PR TITLE
Fix Laravel 9 PHPStan generic check 

### DIFF
--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -6,5 +6,12 @@ use Illuminate\Database\Eloquent\Builder;
 
 interface Filter
 {
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model> $query
+     * @param mixed $value
+     * @param string $property
+     *
+     * @return mixed
+     */
     public function __invoke(Builder $query, $value, string $property);
 }


### PR DESCRIPTION
PHPStan error : Method App\Http\Controllers\Resource\DemoController::withQuery() has parameter $query with generic class Illuminate\Database\Eloquent\Builder but does not specify its types: TModelClass

