### PR TITLE
static return type when returning $this

### DIFF
--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -12,7 +12,7 @@ trait AddsFieldsToQuery
 {
     protected ?Collection $allowedFields = null;
 
-    public function allowedFields($fields): self
+    public function allowedFields($fields): static
     {
         if ($this->allowedIncludes instanceof Collection) {
             throw new AllowedFieldsMustBeCalledBeforeAllowedIncludes();

--- a/src/Concerns/AddsIncludesToQuery.php
+++ b/src/Concerns/AddsIncludesToQuery.php
@@ -12,7 +12,7 @@ trait AddsIncludesToQuery
 {
     protected ?Collection $allowedIncludes = null;
 
-    public function allowedIncludes($includes): self
+    public function allowedIncludes($includes): static
     {
         $includes = is_array($includes) ? $includes : func_get_args();
 

--- a/src/Concerns/FiltersQuery.php
+++ b/src/Concerns/FiltersQuery.php
@@ -10,7 +10,7 @@ trait FiltersQuery
     /** @var \Illuminate\Support\Collection */
     protected $allowedFilters;
 
-    public function allowedFilters($filters): self
+    public function allowedFilters($filters): static
     {
         $filters = is_array($filters) ? $filters : func_get_args();
 

--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -10,7 +10,7 @@ trait SortsQuery
     /** @var \Illuminate\Support\Collection */
     protected $allowedSorts;
 
-    public function allowedSorts($sorts): self
+    public function allowedSorts($sorts): static
     {
         if ($this->request->sorts()->isEmpty()) {
             // We haven't got any requested sorts. No need to parse allowed sorts.
@@ -40,7 +40,7 @@ trait SortsQuery
      *
      * @return \Spatie\QueryBuilder\QueryBuilder
      */
-    public function defaultSort($sorts): self
+    public function defaultSort($sorts): static
     {
         return $this->defaultSorts(func_get_args());
     }
@@ -50,7 +50,7 @@ trait SortsQuery
      *
      * @return \Spatie\QueryBuilder\QueryBuilder
      */
-    public function defaultSorts($sorts): self
+    public function defaultSorts($sorts): static
     {
         if ($this->request->sorts()->isNotEmpty()) {
             // We've got requested sorts. No need to parse defaults.

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -46,7 +46,7 @@ class QueryBuilder implements ArrayAccess
      *
      * @return $this
      */
-    protected function initializeSubject($subject): self
+    protected function initializeSubject($subject): static
     {
         throw_unless(
             $subject instanceof EloquentBuilder || $subject instanceof Relation,
@@ -58,7 +58,7 @@ class QueryBuilder implements ArrayAccess
         return $this;
     }
 
-    protected function initializeRequest(?Request $request = null): self
+    protected function initializeRequest(?Request $request = null): static
     {
         $this->request = $request
             ? QueryBuilderRequest::fromRequest($request)
@@ -91,7 +91,7 @@ class QueryBuilder implements ArrayAccess
      *
      * @return static
      */
-    public static function for($subject, ?Request $request = null): self
+    public static function for($subject, ?Request $request = null): static
     {
         if (is_subclass_of($subject, Model::class)) {
             $subject = $subject::query();


### PR DESCRIPTION
I've changed the return types of some chainable methods in QueryBuilder from `self` to `static`, as it's more precise.

I've noticed this as I'm extending the QueryBuilder class with an additional method.