### PR TITLE
Fix Laravel 9 PHPStan generic check for  `__invoke()` method of Filter

### DIFF
--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -4,10 +4,13 @@ namespace Spatie\QueryBuilder\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ */
 interface Filter
 {
     /**
-     * @param \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model> $query
+     * @param \Illuminate\Database\Eloquent\Builder<TModelClass> $query
      * @param mixed $value
      * @param string $property
      *

--- a/src/Filters/FiltersCallback.php
+++ b/src/Filters/FiltersCallback.php
@@ -4,6 +4,10 @@ namespace Spatie\QueryBuilder\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template-implements \Spatie\QueryBuilder\Filters\Filter<TModelClass>
+ */
 class FiltersCallback implements Filter
 {
     /**

--- a/src/Filters/FiltersExact.php
+++ b/src/Filters/FiltersExact.php
@@ -7,6 +7,10 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template-implements \Spatie\QueryBuilder\Filters\Filter<TModelClass>
+ */
 class FiltersExact implements Filter
 {
     protected $relationConstraints = [];
@@ -19,6 +23,7 @@ class FiltersExact implements Filter
         $this->addRelationConstraint = $addRelationConstraint;
     }
 
+    /** {@inheritdoc} */
     public function __invoke(Builder $query, $value, string $property)
     {
         if ($this->addRelationConstraint) {

--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -4,8 +4,13 @@ namespace Spatie\QueryBuilder\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template-implements \Spatie\QueryBuilder\Filters\Filter<TModelClass>
+ */
 class FiltersPartial extends FiltersExact implements Filter
 {
+    /** {@inheritdoc} */
     public function __invoke(Builder $query, $value, string $property)
     {
         if ($this->addRelationConstraint) {

--- a/src/Filters/FiltersScope.php
+++ b/src/Filters/FiltersScope.php
@@ -13,8 +13,13 @@ use ReflectionParameter;
 use ReflectionUnionType;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterValue;
 
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template-implements \Spatie\QueryBuilder\Filters\Filter<TModelClass>
+ */
 class FiltersScope implements Filter
 {
+    /** {@inheritdoc} */
     public function __invoke(Builder $query, $values, string $property): Builder
     {
         $propertyParts = collect(explode('.', $property));

--- a/src/Filters/FiltersTrashed.php
+++ b/src/Filters/FiltersTrashed.php
@@ -4,6 +4,10 @@ namespace Spatie\QueryBuilder\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template-implements \Spatie\QueryBuilder\Filters\Filter<TModelClass>
+ */
 class FiltersTrashed implements Filter
 {
     /** {@inheritdoc} */

--- a/tests/TestClasses/Filters/FiltersTestModels.php
+++ b/tests/TestClasses/Filters/FiltersTestModels.php
@@ -5,8 +5,13 @@ namespace Spatie\QueryBuilder\Tests\TestClasses\Filters;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Filters\Filter;
 
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template-implements \Spatie\QueryBuilder\Filters\Filter<TModelClass>
+ */
 class FiltersTestModels implements Filter
 {
+    /** {@inheritdoc} */
     public function __invoke(Builder $query, $value, string $property): Builder
     {
         return $query->where($property, $value);


### PR DESCRIPTION
Fix `PHPStan` error of generic check  when `FiltersXXXClass` used for extends. 