### PR TITLE
Add Inertia.js Tables for Laravel Query Builder

### DIFF
--- a/docs/advanced-usage/front-end-implementation.md
+++ b/docs/advanced-usage/front-end-implementation.md
@@ -7,4 +7,6 @@ If you're interested in building query urls on the front-end to match this packa
 
 - Standalone: [elodo package](https://www.npmjs.com/package/elodo) by [Maxim Vanhove](https://github.com/MaximVanhove).
 - Vue: [vue-api-query package](https://github.com/robsontenorio/vue-api-query) by [Robson Tenório](https://github.com/robsontenorio).
+- Vue + Inertia.js: [inertiajs-tables-laravel-query-builder](https://github.com/protonemedia/inertiajs-tables-laravel-query-builder) by [
+Pascal Baljet](https://github.com/pascalbaljet).
 - React: [cogent-js package](https://www.npmjs.com/package/cogent-js) by [Joel Male](https://github.com/joelwmale).


### PR DESCRIPTION
This PR adds the [Inertia.js Tables for Laravel Query Builder](https://github.com/protonemedia/inertiajs-tables-laravel-query-builder) Package to the Front-end implementation list.

Very simple PR. Nothing fancy. I want to make sure more people can find this excellent package by [Pascal Baljet](https://github.com/pascalbaljet)