### PR TITLE
Remove relation name conversion and respect included fields for relations

### DIFF
--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\QueryBuilder\Concerns;
 
-use ReflectionClass;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use ReflectionClass;
 use Spatie\QueryBuilder\Exceptions\AllowedFieldsMustBeCalledBeforeAllowedIncludes;
 use Spatie\QueryBuilder\Exceptions\InvalidFieldQuery;
 use Spatie\QueryBuilder\Exceptions\UnknownIncludedFieldsQuery;
@@ -68,7 +68,7 @@ trait AddsFieldsToQuery
 
         return array_unique([
             ...$this->resolveAdditionallyRequiredKeys($relation),
-            ...$fields
+            ...$fields,
         ]);
     }
 
@@ -127,16 +127,16 @@ trait AddsFieldsToQuery
     {
         [$nestedModel, $nestedRelation] =
             collect(explode('.', $relation))
-            ->reduce(fn($acc, $relationPart) => [
+            ->reduce(fn ($acc, $relationPart) => [
                 $acc[0]->$relationPart()->getModel(),
-                $acc[0]->$relationPart()
+                $acc[0]->$relationPart(),
             ], [$this->getModel(), null]);
 
         $requiredKeys = [ $nestedModel->getKeyName() ];
 
         // We need to query the foreign key only if it is saved on the table
         // of the related model
-        if ( ! ($nestedRelation instanceof BelongsTo)) {
+        if (! ($nestedRelation instanceof BelongsTo)) {
             $requiredKeys[] = $nestedRelation->getForeignKeyName();
         }
 

--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -36,7 +36,7 @@ trait AddsFieldsToQuery
 
     protected function addRequestedModelFieldsToQuery()
     {
-        $modelName = Str::lcfirst((new ReflectionClass($this->getModel()))->getShortName());
+        $modelName = lcfirst((new ReflectionClass($this->getModel()))->getShortName());
 
         $modelFields = $this->request->fields()->get($modelName);
 
@@ -100,7 +100,7 @@ trait AddsFieldsToQuery
     protected function prependField(string $field, ?string $modelName = null): string
     {
         if (! $modelName) {
-            $modelName = Str::lcfirst((new ReflectionClass($this->getModel()))->getShortName());
+            $modelName = lcfirst((new ReflectionClass($this->getModel()))->getShortName());
         }
 
         if (Str::contains($field, '.')) {

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -217,7 +217,7 @@ it('takes allowed fields for a relation into account', function () {
     ]);
 
     $request = new Request([
-        'fields'  => ['relatedModels' => 'id,name'],
+        'fields' => ['relatedModels' => 'id,name'],
         'include' => ['relatedModels'],
     ]);
 


### PR DESCRIPTION
This PR addresses two issues:
- automatic snake_case conversion of included relations: #792, #440, #640
- respecting allowed fields for relationship fields: #681

I've tried to split them originally but the changes go hand-in-hand which is why I decided against it in the end.

Including a relation now requires specifying the exact relation name. This should clear up some confusion that arose with the automatic conversion in the past.

The key and foreign key columns are always queried and included automatically as they are required to associate the loaded models.
I don't know if this automatic resolution is something we want to support as I have a feeling that it won't always be possible.

```php
class TestModel extends Model
{
    public function relatedModels(): HasMany
    {
        return $this->hasMany(RelatedModel::class);
    }
}

// Previously
->allowedIncludes('relatedModels')
->allowedFields('related_models.name')

// Now
->allowedIncludes('relatedModels')
->allowedFields('relatedModels.name') //  Also automatically includes relatedModels.id
```

I've added a test case to verify that included fields for relations are respected, but I'm uncertain how the implementation holds up with more complex model setups. As I don't currently use this package in any of my projects, I can't test it extensively.

Please have a look at it and maybe test the changes. Any feedback or criticism is welcome.
