### PR TITLE
Change self to static when creating query builder

### DIFF
--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -29,7 +29,7 @@ class QueryBuilderRequest extends Request
 
     public static function fromRequest(Request $request): self
     {
-        return static::createFrom($request, new self());
+        return static::createFrom($request, new static());
     }
 
     public function includes(): Collection


### PR DESCRIPTION
Fix for #797

fromRequest mixed static and self; this fixes to only use `static`