### PR TITLE
Add BeginsWithStrict filter

### DIFF
--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -4,6 +4,7 @@ namespace Spatie\QueryBuilder;
 
 use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\Filters\Filter;
+use Spatie\QueryBuilder\Filters\FiltersBeginsWithStrict;
 use Spatie\QueryBuilder\Filters\FiltersCallback;
 use Spatie\QueryBuilder\Filters\FiltersExact;
 use Spatie\QueryBuilder\Filters\FiltersPartial;
@@ -68,6 +69,13 @@ class AllowedFilter
         static::setFilterArrayValueDelimiter($arrayValueDelimiter);
 
         return new static($name, new FiltersPartial($addRelationConstraint), $internalName);
+    }
+
+    public static function beginsWithStrict(string $name, $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): self
+    {
+        static::setFilterArrayValueDelimiter($arrayValueDelimiter);
+
+        return new static($name, new FiltersBeginsWithStrict($addRelationConstraint), $internalName);
     }
 
     public static function scope(string $name, $internalName = null, string $arrayValueDelimiter = null): self

--- a/src/Filters/FiltersBeginsWithStrict.php
+++ b/src/Filters/FiltersBeginsWithStrict.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\QueryBuilder\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template-implements \Spatie\QueryBuilder\Filters\Filter<TModelClass>
+ */
+class FiltersBeginsWithStrict extends FiltersPartial implements Filter
+{
+    protected function applyWhere(Builder $query, $value, string $property)
+    {
+        $wrappedProperty = $query->getQuery()->getGrammar()->wrap($query->qualifyColumn($property));
+
+        $query->whereRaw("{$wrappedProperty} LIKE ?", ["{$value}%"]);
+    }
+}

--- a/src/Filters/FiltersBeginsWithStrict.php
+++ b/src/Filters/FiltersBeginsWithStrict.php
@@ -10,10 +10,11 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class FiltersBeginsWithStrict extends FiltersPartial implements Filter
 {
-    protected function applyWhere(Builder $query, $value, string $property)
+    protected function getWhereRawParameters($value, string $property): array
     {
-        $wrappedProperty = $query->getQuery()->getGrammar()->wrap($query->qualifyColumn($property));
-
-        $query->whereRaw("{$wrappedProperty} LIKE ?", ["{$value}%"]);
+        return [
+            "{$property} LIKE ?",
+            ["{$value}%"],
+        ];
     }
 }

--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -26,7 +26,7 @@ class FiltersPartial extends FiltersExact implements Filter
                 return $query;
             }
 
-            $query->where(function (Builder $query) use ($value, $sql, $property) {
+            $query->where(function (Builder $query) use ($value, $property) {
                 foreach (array_filter($value, 'strlen') as $partialValue) {
                     $this->applyWhere($query, $partialValue, $property);
                 }

--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -28,7 +28,6 @@ class FiltersPartial extends FiltersExact implements Filter
 
             $query->where(function (Builder $query) use ($value, $sql, $property) {
                 foreach (array_filter($value, 'strlen') as $partialValue) {
-                    $partialValue = mb_strtolower($partialValue, 'UTF8');
                     $this->applyWhere($query, $partialValue, $property);
                 }
             });
@@ -36,13 +35,13 @@ class FiltersPartial extends FiltersExact implements Filter
             return;
         }
 
-        $value = mb_strtolower($value, 'UTF8');
-
         $this->applyWhere($query, $value, $property);
     }
 
     protected function applyWhere(Builder $query, $value, string $property)
     {
+        $value = mb_strtolower($value, 'UTF8');
+
         $wrappedProperty = $query->getQuery()->getGrammar()->wrap($query->qualifyColumn($property));
 
         $query->whereRaw("LOWER({$wrappedProperty}) LIKE ?", ["%{$value}%"]);

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -130,6 +130,37 @@ test('falsy values are not ignored when applying a partial filter', function () 
     $this->assertQueryLogContains("select * from `test_models` where (LOWER(`test_models`.`id`) LIKE ?)");
 });
 
+test('falsy values are not ignored when applying a begins with strict filter', function () {
+    DB::enableQueryLog();
+
+    createQueryFromFilterRequest([
+            'id' => [0],
+        ])
+        ->allowedFilters(AllowedFilter::beginsWithStrict('id'))
+        ->get();
+
+    $this->assertQueryLogContains("select * from `test_models` where (`test_models`.`id` LIKE ?)");
+});
+
+it('can filter partial using begins with strict', function () {
+    TestModel::create([
+        'name' => 'John Doe',
+    ]);
+
+    $models = createQueryFromFilterRequest(['name' => 'john'])
+        ->allowedFilters([
+            AllowedFilter::beginsWithStrict('name'),
+        ]);
+
+    $models2 = createQueryFromFilterRequest(['name' => 'doe'])
+        ->allowedFilters([
+            AllowedFilter::beginsWithStrict('name'),
+        ]);
+
+    expect($models->count())->toBe(1);
+    expect($models2->count())->toBe(0);
+});
+
 it('can filter and match results by exact property', function () {
     $testModel = TestModel::first();
 


### PR DESCRIPTION
## Introduction
The current "FiltersPartial" filter is very useful, but, it has some performance issues when we use it in a table with many data (see #820).

This PR introduces the "beginsWithStrict" filter, which may be used in situations described before.

In addition, this PR also allows us to extend the PartialFilter to change only the "where" clause applies (method `getWhereRawParameters`), making it possible implements other cases, like `beginsWith`, `endsWith`, `endsWithStrict`, etc.

## Using
```php
$users = QueryBuilder::for(User::with('media'))
    ->allowedFilters([
        AllowedFilter::beginsWithStrict('name'),
    ])
   // ...
```

## TODO
- [x] Implements BeginsWithStrict
- [x] Cover with Tests

## Related
Closes #820 