### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0]
+                php: [8.2, 8.1, 8.0]
                 laravel: [9.*]
                 stability: [prefer-lowest, prefer-stable]
                 include:


### PR DESCRIPTION
This PR adds PHP 8.2 to the tests workflow.


_id:php82-support/v1_