### PR TITLE
 Add config to disable InvalidSortQuery exception

### DIFF
--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -33,6 +33,12 @@ return [
     'disable_invalid_filter_query_exception' => false,
 
     /*
+     * By default the package will throw an `InvalidSortQuery` exception when a sort in the
+     * URL is not allowed in the `allowedSorts()` method.
+     */
+    'disable_invalid_sort_query_exception' => false,
+
+    /*
      * By default the package inspects query string of request using $request->query().
      * You can change this behavior to inspect the request body using $request->input()
      * by setting this value to `body`.

--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -99,6 +99,10 @@ trait SortsQuery
 
     protected function ensureAllSortsExist(): void
     {
+        if (config('query-builder.disable_invalid_sort_query_exception')) {
+            return;
+        }
+
         $requestedSortNames = $this->request->sorts()->map(function (string $sort) {
             return ltrim($sort, '-');
         });

--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -85,7 +85,7 @@ trait SortsQuery
 
                 $sort = $this->findSort($key);
 
-                $sort->sort($this, $descending);
+                $sort?->sort($this, $descending);
             });
     }
 

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -136,6 +136,15 @@ it('will throw an exception if a sort property is not allowed', function () {
         ->allowedSorts('id');
 });
 
+it('does not throw invalid sort query exception when disable in config', function () {
+    config(['query-builder.disable_invalid_sort_query_exception' => true]);
+
+    createQueryFromSortRequest('name')
+        ->allowedSorts('id');
+
+    expect(true)->toBeTrue();
+});
+
 test('an invalid sort query exception contains the unknown and allowed sorts', function () {
     $exception = InvalidSortQuery::sortsNotAllowed(collect(['unknown sort']), collect(['allowed sort']));
 


### PR DESCRIPTION
Just like the disable InvalidFilterQuery exception we should be able to silently ignore sorting exception