### PR TITLE
Support creating a queryBuilder for a Model instance

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -94,7 +94,11 @@ class QueryBuilder implements ArrayAccess
     public static function for($subject, ?Request $request = null): static
     {
         if (is_subclass_of($subject, Model::class)) {
-            $subject = $subject::query();
+            if(is_object($subject)) {
+                $subject = $subject::query()->where($subject->getKeyName(), $subject->getKey());
+            } else {
+                $subject = $subject::query();
+            }
         }
 
         return new static($subject, $request);

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -280,3 +280,16 @@ it('supports clone as method', function () {
         $queryBuilder2->toSql()
     );
 });
+
+it('can be given an eloquent model', function () {
+    $testModel = TestModel::create(['id' => 123, 'name' => 'John Doe']);
+
+    $queryBuilder = QueryBuilder::for($testModel);
+
+    $eloquentBuilder = TestModel::where('id', 123);
+
+    $this->assertEquals(
+        $eloquentBuilder->toSql(),
+        $queryBuilder->toSql()
+    );
+});


### PR DESCRIPTION
When we construct our APIs, we often have similar endpoints:

GET /accounts returns all accounts
GET /accounts/{account} returns a specific account.

To ensure we provide an API as clean as possible to our consumers, we want to have the same `?include=` and and `?fields` query parameters, so one our `GET /accounts/{account}` endpoint we usually ended up doing the following:

```php
class GetAccountController {
  public function __invoke(Account $account): AccountResource {
    return AccountResource::make(
      QueryBuilder::for(Account::class)
        ->where('id', $account->id)
        ->allowedIncludes([
          AllowedInclude::relationship('address'),
        ])
        ->first()
     );
  }
}
```

This works of course, but becomes a bit verbose, so what we are introducing with this pull request, is that we can also create a QueryBuilder for a model instance, allowing us to rewrite the above to:

```php
class GetAccountController {
  public function __invoke(Account $account): AccountResource {
    return AccountResource::make(
      QueryBuilder::for($account)
        ->allowedIncludes([
          AllowedInclude::relationship('address'),
        ])
        ->first()
     );
  }
}
```

Just one remark: even though it was undocumented, we could already pass in the instance as a parameter for the static `for()` method, but it would actually return a query builder for the Model collection without filtering the actual model instance:

```
public static function for($subject, ?Request $request = null): static
  {
    if (is_subclass_of($subject, Model::class)) {
      $subject = $subject::query();
    }
  }
```

This means that this PR may impact users that rely on being able to just pass down a model instance and it returning the queryBuilder for the Model instead of a queryBuilder that filters for the concrete instance, as we change the above to this:

```
public static function for($subject, ?Request $request = null): static
  {
    if (is_subclass_of($subject, Model::class)) {
      if(is_object($subject)) {
        $subject = $subject::query()->where($subject->getKeyName(), $subject->getKey());
      } else {
         $subject = $subject::query();
      }
    }
    return new static($subject, $request);
  }
```

Hence I would personally suggest releasing this in a major version.

thanks again for considering this PR.