### PR TITLE
Update custom sorts link in documentation

### DIFF
--- a/docs/features/sorting.md
+++ b/docs/features/sorting.md
@@ -7,7 +7,7 @@ The `sort` query parameter is used to determine by which property the results co
 
 All sorts have to be explicitly allowed by passing an array to the `allowedSorts()` method. The `allowedSorts` method takes an array of column names as strings or instances of `AllowedSorts`s.
 
-For more advanced use cases, [custom sorts](#custom-sorts) can be used.
+For more advanced use cases, [custom sorts](#content-custom-sorts) can be used.
 
 ## Basic usage
 


### PR DESCRIPTION
The link "custom sorts" doesn't work. It should link to `#content-custom-sorts`.