### PR TITLE
Update AddsFieldsToQuery.php

### DIFF
--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -49,11 +49,9 @@ trait AddsFieldsToQuery
 
     public function getRequestedFieldsForRelatedTable(string $relation): array
     {
-        $table = Str::plural(Str::snake($relation)); // TODO: make this configurable
-
         $fields = $this->request->fields()->mapWithKeys(function ($fields, $table) {
             return [$table => $fields];
-        })->get($table);
+        })->get(Str::snake($relation));
 
         if (! $fields) {
             return [];


### PR DESCRIPTION
Fix allowFields.
In the query string, fields[brand],"brand" is the relationship.
but, in getRequestedFieldsForRelatedTable, the name of the relationship is transformed into a table name...