### PR TITLE
Change the way AllowedSorts are set

### DIFF
--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -12,12 +12,6 @@ trait SortsQuery
 
     public function allowedSorts($sorts): static
     {
-        if ($this->request->sorts()->isEmpty()) {
-            // We haven't got any requested sorts. No need to parse allowed sorts.
-
-            return $this;
-        }
-
         $sorts = is_array($sorts) ? $sorts : func_get_args();
 
         $this->allowedSorts = collect($sorts)->map(function ($sort) {
@@ -27,6 +21,12 @@ trait SortsQuery
 
             return AllowedSort::field(ltrim($sort, '-'));
         });
+
+        if ($this->request->sorts()->isEmpty()) {
+            // We haven't got any requested sorts. No need to parse allowed sorts.
+
+            return $this;
+        }
 
         $this->ensureAllSortsExist();
 


### PR DESCRIPTION
It turns out that it is the only property that is not set when building the QueryBuilder object, it is only set if there is a request with sort key. I'm doing this PR because I'm making some classes to document my APIs that add an integration between this package and Laravel Scribe, but I can't get the value of AllowedSorts because it's not set unless the request brings the sort key.