### PR TITLE
Accepts string value for query param "fields"

### DIFF
--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -36,7 +36,9 @@ trait AddsFieldsToQuery
     {
         $modelTableName = $this->getModel()->getTable();
 
-        $modelFields = $this->request->fields()->get($modelTableName);
+        $fields = $this->request->fields();
+
+        $modelFields = $fields->has($modelTableName) ? $fields->get($modelTableName) : $fields->get('_');
 
         if (empty($modelFields)) {
             return;
@@ -70,11 +72,13 @@ trait AddsFieldsToQuery
 
     protected function ensureAllFieldsExist()
     {
+        $modelTable = $this->getModel()->getTable();
+
         $requestedFields = $this->request->fields()
-            ->map(function ($fields, $model) {
+            ->map(function ($fields, $model) use ($modelTable) {
                 $tableName = $model;
 
-                return $this->prependFieldsWithTableName($fields, $tableName);
+                return $this->prependFieldsWithTableName($fields, $model === '_' ? $modelTable : $tableName);
             })
             ->flatten()
             ->unique();

--- a/tests/FieldsTest.php
+++ b/tests/FieldsTest.php
@@ -31,7 +31,7 @@ it('fetches all columns if no field was requested but allowed fields were specif
     expect($query)->toEqual($expected);
 });
 
-it('replaces selected columns on the query', function () {
+it('replaces selected array columns on the query', function () {
     $query = createQueryFromFieldRequest(['test_models' => 'name,id'])
         ->select(['id', 'is_visible'])
         ->allowedFields(['name', 'id'])
@@ -45,7 +45,21 @@ it('replaces selected columns on the query', function () {
     $this->assertStringNotContainsString('is_visible', $expected);
 });
 
-it('can fetch specific columns', function () {
+it('replaces selected string columns on the query', function () {
+    $query = createQueryFromFieldRequest('name,id')
+        ->select(['id', 'is_visible'])
+        ->allowedFields(['name', 'id'])
+        ->toSql();
+
+    $expected = TestModel::query()
+        ->select("{$this->modelTableName}.name", "{$this->modelTableName}.id")
+        ->toSql();
+
+    expect($query)->toEqual($expected);
+    $this->assertStringNotContainsString('is_visible', $expected);
+});
+
+it('can fetch specific array columns', function () {
     $query = createQueryFromFieldRequest(['test_models' => 'name,id'])
         ->allowedFields(['name', 'id'])
         ->toSql();
@@ -57,7 +71,19 @@ it('can fetch specific columns', function () {
     expect($query)->toEqual($expected);
 });
 
-it('wont fetch a specific column if its not allowed', function () {
+it('can fetch specific string columns', function () {
+    $query = createQueryFromFieldRequest('name,id')
+        ->allowedFields(['name', 'id'])
+        ->toSql();
+
+    $expected = TestModel::query()
+        ->select("{$this->modelTableName}.name", "{$this->modelTableName}.id")
+        ->toSql();
+
+    expect($query)->toEqual($expected);
+});
+
+it('wont fetch a specific array column if its not allowed', function () {
     $query = createQueryFromFieldRequest(['test_models' => 'random-column'])->toSql();
 
     $expected = TestModel::query()->toSql();
@@ -65,7 +91,15 @@ it('wont fetch a specific column if its not allowed', function () {
     expect($query)->toEqual($expected);
 });
 
-it('can fetch sketchy columns if they are allowed fields', function () {
+it('wont fetch a specific string column if its not allowed', function () {
+    $query = createQueryFromFieldRequest('random-column')->toSql();
+
+    $expected = TestModel::query()->toSql();
+
+    expect($query)->toEqual($expected);
+});
+
+it('can fetch sketchy array columns if they are allowed fields', function () {
     $query = createQueryFromFieldRequest(['test_models' => 'name->first,id'])
         ->allowedFields(['name->first', 'id'])
         ->toSql();
@@ -77,21 +111,47 @@ it('can fetch sketchy columns if they are allowed fields', function () {
     expect($query)->toEqual($expected);
 });
 
-it('guards against not allowed fields', function () {
+it('can fetch sketchy string columns if they are allowed fields', function () {
+    $query = createQueryFromFieldRequest('name->first,id')
+        ->allowedFields(['name->first', 'id'])
+        ->toSql();
+
+    $expected = TestModel::query()
+        ->select("{$this->modelTableName}.name->first", "{$this->modelTableName}.id")
+        ->toSql();
+
+    expect($query)->toEqual($expected);
+});
+
+it('guards against not allowed array fields', function () {
     $this->expectException(InvalidFieldQuery::class);
 
     createQueryFromFieldRequest(['test_models' => 'random-column'])
         ->allowedFields('name');
 });
 
-it('guards against not allowed fields from an included resource', function () {
+it('guards against not allowed string fields', function () {
+    $this->expectException(InvalidFieldQuery::class);
+
+    createQueryFromFieldRequest('random-column')
+        ->allowedFields('name');
+});
+
+it('guards against not allowed array fields from an included resource', function () {
     $this->expectException(InvalidFieldQuery::class);
 
     createQueryFromFieldRequest(['related_models' => 'random_column'])
         ->allowedFields('related_models.name');
 });
 
-it('can fetch only requested columns from an included model', function () {
+it('guards against not allowed string fields from an included resource', function () {
+    $this->expectException(InvalidFieldQuery::class);
+
+    createQueryFromFieldRequest('related_models.random_column')
+        ->allowedFields('related_models.name');
+});
+
+it('can fetch only requested array columns from an included model', function () {
     RelatedModel::create([
         'test_model_id' => $this->model->id,
         'name' => 'related',
@@ -117,7 +177,30 @@ it('can fetch only requested columns from an included model', function () {
     $this->assertQueryLogContains('select `name` from `related_models`');
 });
 
-it('can fetch requested columns from included models up to two levels deep', function () {
+it('can fetch only requested string columns from an included model', function () {
+    RelatedModel::create([
+        'test_model_id' => $this->model->id,
+        'name' => 'related',
+    ]);
+
+    $request = new Request([
+        'fields' => 'id,related_models.name',
+        'include' => ['relatedModels'],
+    ]);
+
+    $queryBuilder = QueryBuilder::for(TestModel::class, $request)
+        ->allowedFields('related_models.name', 'id')
+        ->allowedIncludes('relatedModels');
+
+    DB::enableQueryLog();
+
+    $queryBuilder->first()->relatedModels;
+
+    $this->assertQueryLogContains('select `test_models`.`id` from `test_models`');
+    $this->assertQueryLogContains('select `name` from `related_models`');
+});
+
+it('can fetch requested array columns from included models up to two levels deep', function () {
     RelatedModel::create([
         'test_model_id' => $this->model->id,
         'name' => 'related',
@@ -128,6 +211,27 @@ it('can fetch requested columns from included models up to two levels deep', fun
             'test_models' => 'id,name',
             'related_models.test_models' => 'id',
         ],
+        'include' => ['relatedModels.testModel'],
+    ]);
+
+    $result = QueryBuilder::for(TestModel::class, $request)
+        ->allowedFields('related_models.test_models.id', 'id', 'name')
+        ->allowedIncludes('relatedModels.testModel')
+        ->first();
+
+    $this->assertArrayHasKey('name', $result);
+
+    expect($result->relatedModels->first()->testModel->toArray())->toEqual(['id' => $this->model->id]);
+});
+
+it('can fetch requested string columns from included models up to two levels deep', function () {
+    RelatedModel::create([
+        'test_model_id' => $this->model->id,
+        'name' => 'related',
+    ]);
+
+    $request = new Request([
+        'fields' => 'id,name,related_models.test_models.id',
         'include' => ['relatedModels.testModel'],
     ]);
 
@@ -211,7 +315,7 @@ it('wont use sketchy field requests', function () {
 });
 
 // Helpers
-function createQueryFromFieldRequest(array $fields = []): QueryBuilder
+function createQueryFromFieldRequest(array|string $fields = []): QueryBuilder
 {
     $request = new Request([
         'fields' => $fields,


### PR DESCRIPTION
In addition to accepting GET param `fields` like

```
fields[table1]=col1,col2&fields[table2]=col1,col2
```

this PR makes it possible to accept values like

```
fields=table1.col1,table1.col2,table2.col1,table2.col2
```

And if `table1` is the table for the target resource, then it can simply be like

```
fields=col1,col2,table2.col1,table2.col2
```