### PR TITLE
Unset default of AllowedFilter after it was set once, which was possible with default(null) before nullable filters where implemented in 5.6.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.2, 8.1, 8.0]
+                php: [8.3, 8.2, 8.1, 8.0]
                 laravel: [9.*, 10.*]
                 stability: [prefer-lowest, prefer-stable]
                 include:

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -153,6 +153,7 @@ class AllowedFilter
         $this->default = $value;
 
         if (is_null($value)) {
+            $this->unsetDefault();
             $this->nullable(true);
         }
 
@@ -172,6 +173,14 @@ class AllowedFilter
     public function nullable(bool $nullable = true): self
     {
         $this->nullable = $nullable;
+
+        return $this;
+    }
+
+    public function unsetDefault(): self
+    {
+        $this->hasDefault = false;
+        unset($this->default);
 
         return $this;
     }

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -153,7 +153,6 @@ class AllowedFilter
         $this->default = $value;
 
         if (is_null($value)) {
-            $this->unsetDefault();
             $this->nullable(true);
         }
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -562,6 +562,28 @@ it('should apply a nullable filter when filter exists and is set', function () {
     expect($models->count())->toEqual(1);
 });
 
+it('should filter by query parameters if a default value is set and unset afterwards', function () {
+    TestModel::create(['name' => 'John Doe']);
+
+    $filterWithDefault = AllowedFilter::exact('name')->default('some default value');
+    $models = createQueryFromFilterRequest([
+            'name' => 'John Doe',
+        ])
+        ->allowedFilters($filterWithDefault->unsetDefault())
+        ->get();
+
+    expect($models->count())->toEqual(1);
+});
+
+it('should not filter at all if a default value is set and unset afterwards', function () {
+    $filterWithDefault = AllowedFilter::exact('name')->default('some default value');
+    $models = createQueryFromFilterRequest([])
+        ->allowedFilters($filterWithDefault->unsetDefault())
+        ->get();
+
+    expect($models->count())->toEqual(5);
+});
+
 it('should apply a filter with a multi-dimensional array value', function () {
     TestModel::create(['name' => 'John Doe']);
 


### PR DESCRIPTION
The changes from #895 aren't backwards compatible.

`AllowedFilter::scope('test')->default('myDefaultValue')->default(null)` does not unset the default value anymore.

Background: We have a static `allowedFilters` method in a model, such that we can use the same set of `AllowedFilter`s in multiple controllers: 

In `TestModel`:
```php
public static function allowedFilters(): array
{
        return [
                AllowedFilter::scope('test')->default('myDefaultValue'),
                // ...
        ];
}
```

We can use the following in multiple controllers:
```php
$testModels = QueryBuilder::for(TestModel::class)
        ->allowedFilters(TestModel::allowedFilters())
```

Removing one of the default values from the array `allowedFilters()` when using the filter worked with Laravel Query Builder 5.5.0, but not with 5.6.0:
```php
$allowedFilters = [];
foreach (TestModel::allowedFilters() as $allowedFilter) {
        $allowedFilter->default(null);
        $allowedFilters[] = $allowedFilter;
}
$testModels = QueryBuilder::for(TestModel::class)
        ->allowedFilters($allowedFilters);
```

This PR introduces a new `unsetDefault()` method which could be used instead of the `default(null)` call in the example above. This behavior is not fully backwards compatible as one should be able to expect according to Semantic Versioning used by this project.