### PR TITLE
Changing the input arguments of the defaultSort function

### DIFF
--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -36,7 +36,9 @@ trait SortsQuery
      */
     public function defaultSort($sorts): static
     {
-        return $this->defaultSorts(func_get_args());
+        $sorts = is_array($sorts) ? $sorts : func_get_args();
+        
+        return $this->defaultSorts($sorts);
     }
 
     /**


### PR DESCRIPTION
Changing the input arguments of the defaultSort function for more power in the input of this function

Please release this in the box, I had a problem with it myself, and this code solved my problem and it is reasonable.
You put an array in phpdoc, but it can't get the array