### PR TITLE
add option disable_invalid_includes_query_exception

### DIFF
--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -43,4 +43,10 @@ return [
      * URL is not allowed in the `allowedSorts()` method.
      */
     'disable_invalid_sort_query_exception' => false,
+
+    /*
+     * By default the package will throw an `InvalidIncludeQuery` exception when an include in the
+     * URL is not allowed in the `allowedIncludes()` method.
+     */
+    'disable_invalid_includes_query_exception' => false,
 ];

--- a/src/Concerns/AddsIncludesToQuery.php
+++ b/src/Concerns/AddsIncludesToQuery.php
@@ -45,7 +45,9 @@ trait AddsIncludesToQuery
 
         $this->ensureAllIncludesExist();
 
-        $this->addIncludesToQuery($this->request->includes());
+        $includes = $this->filterNonExistingIncludes($this->request->includes());
+
+        $this->addIncludesToQuery($includes);
 
         return $this;
     }
@@ -69,6 +71,10 @@ trait AddsIncludesToQuery
 
     protected function ensureAllIncludesExist()
     {
+        if (config('query-builder.disable_invalid_includes_query_exception', false)) {
+            return;
+        }
+
         $includes = $this->request->includes();
 
         $allowedIncludeNames = $this->allowedIncludes->map(function (AllowedInclude $allowedInclude) {
@@ -82,5 +88,16 @@ trait AddsIncludesToQuery
         }
 
         // TODO: Check for non-existing relationships?
+    }
+
+    protected function filterNonExistingIncludes(Collection $includes): Collection
+    {
+        if (config('query-builder.disable_invalid_includes_query_exception', false) == false) {
+            return $includes;
+        }
+
+        return $includes->filter(function ($include) {
+            return $this->findInclude($include);
+        });
     }
 }

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -236,6 +236,15 @@ it('guards against invalid includes', function () {
         ->allowedIncludes('relatedModels');
 });
 
+it('does not throw invalid include query exception when disable in config', function () {
+    config(['query-builder.disable_invalid_includes_query_exception' => true]);
+
+    createQueryFromIncludeRequest('random-model')
+        ->allowedIncludes('relatedModels');
+
+    expect(true)->toBeTrue();
+});
+
 it('can allow multiple includes', function () {
     $models = createQueryFromIncludeRequest('relatedModels')
         ->allowedIncludes('relatedModels', 'otherRelatedModels')


### PR DESCRIPTION
By default when we add a non desired include, we automatically have an `InvalidIncludeQuery`. The option `disable_invalid_includes_query_exception` allow us to disable it. 

When this option is enabled,  we remove the non included relationship and having only allowed relationships.