### PR TITLE
Add the possibility to use the relation names on the allowedFields.

### DIFF
--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -48,5 +48,5 @@ return [
      * By default, the package convert the relationship names to snake case plural when using fields[relationship].
      * Set this to false if you don't want that and keep the relationship names.
      */
-    'convert_to_snake_case_plural' => true,
+    'convert_relation_names_to_snake_case_plural' => true,
 ];

--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -43,4 +43,10 @@ return [
      * URL is not allowed in the `allowedSorts()` method.
      */
     'disable_invalid_sort_query_exception' => false,
+
+    /*
+     * By default, the package convert the relationship names to snake case plural when using fields[relationship].
+     * Set this to false if you don't want that and keep the relationship names.
+     */
+    'convert_to_snake_case_plural' => true,
 ];

--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -51,11 +51,13 @@ trait AddsFieldsToQuery
 
     public function getRequestedFieldsForRelatedTable(string $relation): array
     {
-        $table = Str::plural(Str::snake($relation)); // TODO: make this configurable
+        $tableOrRelation = config('query-builder.convert_to_snake_case_plural', true)
+            ? Str::plural(Str::snake($relation))
+            : $relation;
 
         $fields = $this->request->fields()
             ->mapWithKeys(fn ($fields, $table) => [$table => $fields])
-            ->get($table);
+            ->get($tableOrRelation);
 
         if (! $fields) {
             return [];

--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -51,7 +51,7 @@ trait AddsFieldsToQuery
 
     public function getRequestedFieldsForRelatedTable(string $relation): array
     {
-        $tableOrRelation = config('query-builder.convert_to_snake_case_plural', true)
+        $tableOrRelation = config('query-builder.convert_relation_names_to_snake_case_plural', true)
             ? Str::plural(Str::snake($relation))
             : $relation;
 


### PR DESCRIPTION
Problem:

Package currently converts relation names to plural snake_case in fields parameters, causing inconsistencies when using singular relation names in API requests.

Suppose that I have the bellow model:

```php
class Task extends Model
{
    public function user(): BelongsTo
    {
        return $this->belongsTo(User::class);
    }
    
    public function userOwnerTestName(): BelongsTo
    {
        return $this->belongsTo(User::class, 'user_id');
    }
}
```

I would like to request the userOwnerTestName relationship, my first try was do this:

`
api/v1/tasks?include=userOwnerTestName&fields[userOwnerTestName]=id,email&fields[tasks]=user_id
`

and the response is:

```json
 "data": [
    {
        "user_id": "9b055f1c-caae-40ca-aa4a-79a5a42a9dd3",
        "userOwnerTestName": {
            "id": "9b055f1c-caae-40ca-aa4a-79a5a42a9dd3",
            "name": "Mavis Erdman I",
            "email": "delilah.walker@example.com"
        }
    },
    {
        "user_id": "9b055f1c-caae-40ca-aa4a-79a5a42a9dd3",
        "userOwnerTestName": {
            "id": "9b055f1c-caae-40ca-aa4a-79a5a42a9dd3",
            "name": "Mavis Erdman I",
            "email": "delilah.walker@example.com"
        }
    },
]
```

But I was expecting:

```json
 "data": [
    {
        "user_id": "9b055f1c-caae-40ca-aa4a-79a5a42a9dd3",
        "userOwnerTestName": {
            "id": "9b055f1c-caae-40ca-aa4a-79a5a42a9dd3",
            "email": "delilah.walker@example.com"
        }
    },
    {
        "user_id": "9b055f1c-caae-40ca-aa4a-79a5a42a9dd3",
        "userOwnerTestName": {
            "id": "9b055f1c-caae-40ca-aa4a-79a5a42a9dd3",
            "email": "delilah.walker@example.com"
        }
    },
]
```

If I change the request to:

`
api/v1/tasks?include=userOwnerTestName&fields[user_owner_test_names]=id,email&fields[tasks]=user_id
`

it works like a charm! But I need to convert the relationship name to plural and use the snake_case format.


Solution:

Introduce a configuration option to control relation name conversion:

- convert_relation_names_to_snake_case_plural: true (default behavior)
- convert_relation_names_to_snake_case_plural: false (preserves original relation names)

Example Usage:

```
// Original behavior (plural snake_case):
api/tasks?include=userOwnerTestName&fields[user_owner_test_names]=id,name
```

```
// New behavior (preserves relation name):
api/tasks?include=userOwnerTestName&fields[userOwnerTestName]=id,name
```