### PR TITLE
fix for incorrect sql LIKE escaping for some db drivers while performing partial filter

### DIFF
--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -3,6 +3,7 @@
 namespace Spatie\QueryBuilder\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 
 /**
  * @template TModelClass of \Illuminate\Database\Eloquent\Model
@@ -47,7 +48,7 @@ class FiltersPartial extends FiltersExact implements Filter
         $value = mb_strtolower((string) $value, 'UTF8');
 
         return [
-            "LOWER({$property}) LIKE ?",
+            "LOWER({$property}) LIKE ?".self::maybeSpecifyEscapeChar(),
             ['%'.self::escapeLike($value).'%'],
         ];
     }
@@ -59,5 +60,14 @@ class FiltersPartial extends FiltersExact implements Filter
             ['\\\\', '\\_', '\\%'],
             $value,
         );
+    }
+
+    private static function maybeSpecifyEscapeChar(): string
+    {
+        if(!in_array(DB::getDriverName(), ["sqlite","pgsql","sqlsrv"])){
+            return "";
+        }
+
+        return " ESCAPE '\'";        
     }
 }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
+use Pest\Expectation;
 use function PHPUnit\Framework\assertObjectHasProperty;
 
 use Spatie\QueryBuilder\AllowedFilter;
@@ -86,8 +87,30 @@ it('can filter a custom base query with select', function () {
         ->where(DB::raw('LOWER(`test_models`.`name`)'), 'LIKE', 'john')
         ->toSql();
 
-    expect($queryBuilderSql)->toEqual($expectedSql);
+    expect($queryBuilderSql)->toContain($expectedSql);
 });
+
+it('specifies escape character in supported databases', function (string $dbDriver) {
+    $fakeConnection = "test_{$dbDriver}";
+    
+    DB::connectUsing($fakeConnection, [
+        'driver' => $dbDriver,
+        'database' => null,
+    ]);
+
+    DB::usingConnection($fakeConnection, function() use ($dbDriver){
+        $request = new Request([
+            'filter' => ['name' => 'to_find'],
+        ]);
+
+        $queryBuilderSql = QueryBuilder::for(TestModel::select('id', 'name'), $request)
+            ->allowedFilters('name', 'id')
+            ->toSql();
+
+        expect($queryBuilderSql)->when(in_array($dbDriver, ["sqlite","pgsql","sqlsrv"]), fn(Expectation $query) => $query->toContain("ESCAPE '\'"));
+        expect($queryBuilderSql)->when($dbDriver === 'mysql', fn(Expectation $query) => $query->not->toContain("ESCAPE '\'"));
+    });
+})->with(['sqlite', 'mysql', 'pgsql', 'sqlsrv']);
 
 it('can filter results based on the existence of a property in an array', function () {
     $results = createQueryFromFilterRequest([


### PR DESCRIPTION
Hi everyone!
First of all, thanks for the amazing package:)

So, I stumbled upon what I think it's a bug in the sql LIKE escaping for special chars (`_`, `%`, `\`).

Consider the following example:
There's a table, which we'll call `companies`, having a column for the company name: `name`.
In this column, we store company names with underscores (maybe a slug, for example).

Here's the problem:
when the table gets filtered from the `QueryBuilder` by the `name` column, if the search value contains an underscore (for example), the underlying query, rightfully, escape this underscore (this happens in `FilterPartials::escapeLike`) making the query become something like `SELECT * FROM companies WHERE name LIKE '%some\_value%'`.
According to my testing, in some database drivers (mysql, pgsql) this escape is automatically interpreted and all is fine, but in some other cases (sqlite, sqlsrv) the `\` is literally interpreted, if not explicitly told otherwise. (I was using sqlite as a test database, so that's why I noticed something off).
In the latter cases, the filtering will happen while looking for a company with name containing `some\_value` (with the `\` NOT being an escape char but a literal char) and, for this reason, failing the matching.

Solution:
some databases support explicitly telling what's the escaper char, using `ESCAPE`, so appending `ESCAPE '\'` at the end of the query, will tell the db to use the `\` char as escape char and not as literal char.
The mysql driver doesn't seem to support such feature, so here's why the check for the db driver (mysql/mariadb would throw a syntax error if used with `ESCAPE`).

Here's the file containing my testing mentioned above:
[escaping_test.txt](https://github.com/spatie/laravel-query-builder/files/14606742/escaping_test.txt)

Just a note to finish:
some tests were failing before this fix: `Tests:    37 failed, 2 skipped, 174 passed (267 assertions)`
after the fix: `Tests:    37 failed, 2 skipped, 178 passed (271 assertions)`
So I don't think my implementation is causing the fails.
The only test i changed is in FilterTest, line 90, as it was checking for an exact string match, but after the change to the query, it wouldn't pass, so i made it look for a partial match (before: `...->toEqual(...)`, now `...->toContian(...)`).

I apologize if my English for the explanation of the problem/solution may lack of clarity.


