### PR TITLE
Support one whereHas for several filters.

### DIFF
--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -128,6 +128,11 @@ class AllowedFilter
         return $this->name;
     }
 
+    public function getNames(): array
+    {
+        return [$this->getName()];
+    }
+
     public function isForFilter(string $filterName): bool
     {
         return $this->name === $filterName;
@@ -198,5 +203,20 @@ class AllowedFilter
         }
 
         return ! $this->ignored->contains($value) ? $value : null;
+    }
+
+    public function isFilterRequested(QueryBuilderRequest $request): bool
+    {
+        return $request->filters()->has($this->getName());
+    }
+
+    public function getValueFromRequest(QueryBuilderRequest $request): mixed
+    {
+        return $request->filters()->get($this->getName());
+    }
+
+    public function getValueFromCollection(Collection $value): mixed
+    {
+        return $value->get($this->getName());
     }
 }

--- a/src/AllowedRelationshipFilter.php
+++ b/src/AllowedRelationshipFilter.php
@@ -41,7 +41,7 @@ class AllowedRelationshipFilter extends AllowedFilter
     public function getNames(): array
     {
         return $this->allowedFilters->map(
-            fn(AllowedFilter $allowedFilter) => $allowedFilter->getNames()
+            fn (AllowedFilter $allowedFilter) => $allowedFilter->getNames()
         )->flatten()->toArray();
     }
 

--- a/src/AllowedRelationshipFilter.php
+++ b/src/AllowedRelationshipFilter.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Spatie\QueryBuilder;
+
+use Illuminate\Support\Collection;
+
+class AllowedRelationshipFilter extends AllowedFilter
+{
+    /** @var string */
+    protected $relationship;
+
+    /** @var \Illuminate\Support\Collection */
+    protected $allowedFilters;
+
+    public function __construct(string $relationship, AllowedFilter ...$allowedFilters)
+    {
+        $this->relationship = $relationship;
+
+        $this->allowedFilters = collect($allowedFilters);
+    }
+
+    public static function group(string $relationship, AllowedFilter ...$allowedFilters): self
+    {
+        return new static($relationship, ...$allowedFilters);
+    }
+
+    public function filter(QueryBuilder $query, $value)
+    {
+        $query->whereHas($this->relationship, function ($query) use ($value) {
+            $this->allowedFilters->each(
+                function (AllowedFilter $allowedFilter) use ($query, $value) {
+                    $allowedFilter->filter(
+                        QueryBuilder::for($query),
+                        $allowedFilter->getValueFromCollection($value)
+                    );
+                }
+            );
+        });
+    }
+
+    public function getNames(): array
+    {
+        return $this->allowedFilters->map(
+            fn(AllowedFilter $allowedFilter) => $allowedFilter->getNames()
+        )->flatten()->toArray();
+    }
+
+    public function isFilterRequested(QueryBuilderRequest $request): bool
+    {
+        return $request->filters()->hasAny($this->getNames());
+    }
+
+    public function getValueFromRequest(QueryBuilderRequest $request): Collection
+    {
+        return $request->filters()->only($this->getNames());
+    }
+
+    public function getValueFromCollection(Collection $value): Collection
+    {
+        return $value->only($this->getNames());
+    }
+}

--- a/src/Concerns/FiltersQuery.php
+++ b/src/Concerns/FiltersQuery.php
@@ -33,7 +33,7 @@ trait FiltersQuery
     {
         $this->allowedFilters->each(function (AllowedFilter $filter) {
             if ($this->isFilterRequested($filter)) {
-                $value = $this->request->filters()->get($filter->getName());
+                $value = $filter->getValueFromRequest($this->request);
                 $filter->filter($this, $value);
 
                 return;
@@ -57,7 +57,7 @@ trait FiltersQuery
 
     protected function isFilterRequested(AllowedFilter $allowedFilter): bool
     {
-        return $this->request->filters()->has($allowedFilter->getName());
+        return $allowedFilter->isFilterRequested($this->request);
     }
 
     protected function ensureAllFiltersExist()
@@ -69,8 +69,8 @@ trait FiltersQuery
         $filterNames = $this->request->filters()->keys();
 
         $allowedFilterNames = $this->allowedFilters->map(function (AllowedFilter $allowedFilter) {
-            return $allowedFilter->getName();
-        });
+            return $allowedFilter->getNames();
+        })->flatten();
 
         $diff = $filterNames->diff($allowedFilterNames);
 

--- a/tests/RelationFilterTest.php
+++ b/tests/RelationFilterTest.php
@@ -129,9 +129,9 @@ it('defaults to separate exist clauses for each relationship allowed filter', fu
     $nestedRelatedModelToFind->save();
 
     $query = createQueryFromFilterRequest([
-        'relatedModels.id'                       => $relatedModelToFind->id,
-        'relatedModels.name'                     => 'asdf',
-        'relatedModels.nestedRelatedModels.id'   => $nestedRelatedModelToFind->id,
+        'relatedModels.id' => $relatedModelToFind->id,
+        'relatedModels.name' => 'asdf',
+        'relatedModels.nestedRelatedModels.id' => $nestedRelatedModelToFind->id,
         'relatedModels.nestedRelatedModels.name' => 'ghjk',
     ])->allowedFilters([
         AllowedFilter::exact('relatedModels.id'),
@@ -160,9 +160,9 @@ it('can group filters in same exist clause', function () {
     $nestedRelatedModelToFind->save();
 
     $query = createQueryFromFilterRequest([
-        'relatedModels.id'                       => $relatedModelToFind->id,
-        'relatedModels.name'                     => 'asdf',
-        'relatedModels.nestedRelatedModels.id'   => $nestedRelatedModelToFind->id,
+        'relatedModels.id' => $relatedModelToFind->id,
+        'relatedModels.name' => 'asdf',
+        'relatedModels.nestedRelatedModels.id' => $nestedRelatedModelToFind->id,
         'relatedModels.nestedRelatedModels.name' => 'ghjk',
     ])->allowedFilters([
         AllowedRelationshipFilter::group('relatedModels', ...[
@@ -171,8 +171,8 @@ it('can group filters in same exist clause', function () {
             AllowedRelationshipFilter::group('nestedRelatedModels', ...[
                 AllowedFilter::exact('relatedModels.nestedRelatedModels.id', 'id'),
                 AllowedFilter::exact('relatedModels.nestedRelatedModels.name', 'name'),
-            ])
-        ])
+            ]),
+        ]),
     ]);
 
     $models = $query->get();

--- a/tests/RelationFilterTest.php
+++ b/tests/RelationFilterTest.php
@@ -118,7 +118,6 @@ it('can disable partial filtering based on related model properties', function (
 });
 
 it('defaults to separate exist clauses for each relationship allowed filter', function () {
-
     $modelToFind = $this->models->first();
 
     $relatedModelToFind = $modelToFind->relatedModels->first();
@@ -147,11 +146,9 @@ it('defaults to separate exist clauses for each relationship allowed filter', fu
     expect($rawSql)->toBe("select * from `test_models` where exists (select * from `related_models` where `test_models`.`id` = `related_models`.`test_model_id` and `related_models`.`id` = 1) and exists (select * from `related_models` where `test_models`.`id` = `related_models`.`test_model_id` and `related_models`.`name` = 'asdf') and exists (select * from `related_models` where `test_models`.`id` = `related_models`.`test_model_id` and exists (select * from `nested_related_models` where `related_models`.`id` = `nested_related_models`.`related_model_id` and `nested_related_models`.`id` = 1)) and exists (select * from `related_models` where `test_models`.`id` = `related_models`.`test_model_id` and exists (select * from `nested_related_models` where `related_models`.`id` = `nested_related_models`.`related_model_id` and `nested_related_models`.`name` = 'ghjk'))");
     expect($models)->toHaveCount(1);
     expect($models->first()->id)->toBe($modelToFind->id);
-
 });
 
 it('can group filters in same exist clause', function () {
-
     $modelToFind = $this->models->first();
 
     $relatedModelToFind = $modelToFind->relatedModels->first();
@@ -184,5 +181,4 @@ it('can group filters in same exist clause', function () {
     expect($rawSql)->toBe("select * from `test_models` where exists (select * from `related_models` where `test_models`.`id` = `related_models`.`test_model_id` and `related_models`.`id` = 1 and `related_models`.`name` = 'asdf' and exists (select * from `nested_related_models` where `related_models`.`id` = `nested_related_models`.`related_model_id` and `nested_related_models`.`id` = 1 and `nested_related_models`.`name` = 'ghjk'))");
     expect($models)->toHaveCount(1);
     expect($models->first()->id)->toBe($modelToFind->id);
-
 });


### PR DESCRIPTION
This PR adds `AllowedRelationshipFilter` class to be used when wanting to group multiple `AllowedFilter`'s into the same exists query.

### Problem:
When using multiple `AllowedFilter`'s for nested relations - the package adds mutliple exist clauses to the query.

```php
->allowedFilters([
    AllowedFilter::exact('relatedModels.id'),
    AllowedFilter::exact('relatedModels.name'),
    AllowedFilter::exact('relatedModels.nestedRelatedModels.id'),
    AllowedFilter::exact('relatedModels.nestedRelatedModels.name'),
])
```

```sql
SELECT
    *
FROM
    `test_models`
WHERE
    EXISTS (
        SELECT
            *
        FROM
            `related_models`
        WHERE
            `test_models`.`id` = `related_models`.`test_model_id`
            AND `related_models`.`id` = 1)
        AND EXISTS (
            SELECT
                *
            FROM
                `related_models`
            WHERE
                `test_models`.`id` = `related_models`.`test_model_id`
                AND `related_models`.`name` = 'asdf')
            AND EXISTS (
                SELECT
                    *
                FROM
                    `related_models`
                WHERE
                    `test_models`.`id` = `related_models`.`test_model_id`
                    AND EXISTS (
                        SELECT
                            *
                        FROM
                            `nested_related_models`
                        WHERE
                            `related_models`.`id` = `nested_related_models`.`related_model_id`
                            AND `nested_related_models`.`id` = 1))
                    AND EXISTS (
                        SELECT
                            *
                        FROM
                            `related_models`
                        WHERE
                            `test_models`.`id` = `related_models`.`test_model_id`
                            AND EXISTS (
                                SELECT
                                    *
                                FROM
                                    `nested_related_models`
                                WHERE
                                    `related_models`.`id` = `nested_related_models`.`related_model_id`
                                    AND `nested_related_models`.`name` = 'ghjk'))
```

Resulting in 6 `EXISTS` queries.

### Desired Query

```sql
SELECT
    *
FROM
    `test_models`
WHERE
    EXISTS (
        SELECT
            *
        FROM
            `related_models`
        WHERE
            `test_models`.`id` = `related_models`.`test_model_id`
            AND `related_models`.`id` = 1
            AND `related_models`.`name` = 'asdf'
            AND EXISTS (
                SELECT
                    *
                FROM
                    `nested_related_models`
                WHERE
                    `related_models`.`id` = `nested_related_models`.`related_model_id`
                    AND `nested_related_models`.`id` = 1
                    AND `nested_related_models`.`name` = 'ghjk'))
```

Resulting in 2 `EXISTS` queries.

I have seen various requests for this in the past, for example

https://github.com/spatie/laravel-query-builder/discussions/634

https://github.com/spatie/laravel-query-builder/discussions/663

---

At this point just looking for your thoughts and feedback on this. I'm not particually happy with the solution in this PR, feels quite hacky around the existing `AllowedFilter` class.

To me, this feels like quite an important missing feature of this package and if the core maintainers could give some feedback, insight and pointers on this then I'm happy to make the changes and then update documentation to match.