### PR TITLE
[FEAT] add filter by operator

### DIFF
--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -3,11 +3,13 @@
 namespace Spatie\QueryBuilder;
 
 use Illuminate\Support\Collection;
+use Spatie\QueryBuilder\Enums\FilterOperator;
 use Spatie\QueryBuilder\Filters\Filter;
 use Spatie\QueryBuilder\Filters\FiltersBeginsWithStrict;
 use Spatie\QueryBuilder\Filters\FiltersCallback;
 use Spatie\QueryBuilder\Filters\FiltersEndsWithStrict;
 use Spatie\QueryBuilder\Filters\FiltersExact;
+use Spatie\QueryBuilder\Filters\FiltersOperator;
 use Spatie\QueryBuilder\Filters\FiltersPartial;
 use Spatie\QueryBuilder\Filters\FiltersScope;
 use Spatie\QueryBuilder\Filters\FiltersTrashed;
@@ -104,6 +106,13 @@ class AllowedFilter
         static::setFilterArrayValueDelimiter($arrayValueDelimiter);
 
         return new static($name, $filterClass, $internalName);
+    }
+
+    public static function operator(string $name, FilterOperator $filterOperator, string $boolean = 'and', ?string $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): self
+    {
+        static::setFilterArrayValueDelimiter($arrayValueDelimiter);
+
+        return new static($name, new FiltersOperator($addRelationConstraint, $filterOperator, $boolean), $internalName, $filterOperator);
     }
 
     public function getFilterClass(): Filter

--- a/src/Enums/FilterOperator.php
+++ b/src/Enums/FilterOperator.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\QueryBuilder\Enums;
+
+enum FilterOperator: string
+{
+    case EQUAL = '=';
+    case NOT_EQUAL = '<>';
+    case LESS_THAN = '<';
+    case GREATER_THAN = '>';
+    case LESS_THAN_OR_EQUAL = '<=';
+    case GREATER_THAN_OR_EQUAL = '>=';
+}

--- a/src/Enums/FilterOperator.php
+++ b/src/Enums/FilterOperator.php
@@ -4,10 +4,16 @@ namespace Spatie\QueryBuilder\Enums;
 
 enum FilterOperator: string
 {
+    case DYNAMIC = '';
     case EQUAL = '=';
-    case NOT_EQUAL = '<>';
     case LESS_THAN = '<';
     case GREATER_THAN = '>';
     case LESS_THAN_OR_EQUAL = '<=';
     case GREATER_THAN_OR_EQUAL = '>=';
+    case NOT_EQUAL = '<>';
+
+    public function isDynamic()
+    {
+        return self::DYNAMIC === $this;
+    }
 }

--- a/src/Filters/FiltersOperator.php
+++ b/src/Filters/FiltersOperator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\QueryBuilder\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Enums\FilterOperator;
+
+/**
+ * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template-implements \Spatie\QueryBuilder\Filters\Filter<TModelClass>
+ */
+class FiltersOperator extends FiltersExact implements Filter
+{
+    public function __construct(protected bool $addRelationConstraint, protected FilterOperator $filterOperator, protected string $boolean)
+    {
+    }
+
+    /** {@inheritdoc} */
+    public function __invoke(Builder $query, $value, string $property)
+    {
+        if ($this->addRelationConstraint) {
+            if ($this->isRelationProperty($query, $property)) {
+                $this->withRelationConstraint($query, $value, $property);
+
+                return;
+            }
+        }
+
+        if (is_array($value)) {
+            $query->where(function ($query) use ($value, $property) {
+                foreach($value as $item) {
+                    $this->__invoke($query, $item, $property);
+                }
+            });
+
+            return;
+        }
+
+        $query->where($query->qualifyColumn($property), $this->filterOperator->value, $value, $this->boolean);
+    }
+}

--- a/src/Filters/FiltersOperator.php
+++ b/src/Filters/FiltersOperator.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\QueryBuilder\Filters;
 
-use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Enums\FilterOperator;
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -684,7 +684,7 @@ it('can filter name with not equal operator filter', function () {
     expect($results)->toHaveCount(5);
 });
 
-it('can filter name with greater than operator filter', function () {
+it('can filter salary with greater than operator filter', function () {
     TestModel::create(['salary' => 5000]);
 
     $results = createQueryFromFilterRequest([
@@ -696,7 +696,7 @@ it('can filter name with greater than operator filter', function () {
     expect($results)->toHaveCount(1);
 });
 
-it('can filter name with less than operator filter', function () {
+it('can filter salary with less than operator filter', function () {
     TestModel::create(['salary' => 5000]);
 
     $results = createQueryFromFilterRequest([
@@ -708,7 +708,7 @@ it('can filter name with less than operator filter', function () {
     expect($results)->toHaveCount(1);
 });
 
-it('can filter name with greater than or equal operator filter', function () {
+it('can filter salary with greater than or equal operator filter', function () {
     TestModel::create(['salary' => 5000]);
 
     $results = createQueryFromFilterRequest([
@@ -720,7 +720,7 @@ it('can filter name with greater than or equal operator filter', function () {
     expect($results)->toHaveCount(1);
 });
 
-it('can filter name with less than or equal operator filter', function () {
+it('can filter salary with less than or equal operator filter', function () {
     TestModel::create(['salary' => 5000]);
 
     $results = createQueryFromFilterRequest([
@@ -740,6 +740,34 @@ it('can filter array of names with equal operator filter', function () {
             'name' => 'John Doe,Max Doe',
         ])
         ->allowedFilters(AllowedFilter::operator('name', FilterOperator::EQUAL, 'or'))
+        ->get();
+
+    expect($results)->toHaveCount(2);
+});
+
+it('can filter salary with dynamic operator filter', function () {
+    TestModel::create(['salary' => 5000]);
+    TestModel::create(['salary' => 2000]);
+
+    $results = createQueryFromFilterRequest([
+            'salary' => '>2000',
+        ])
+        ->allowedFilters(AllowedFilter::operator('salary', FilterOperator::DYNAMIC))
+        ->get();
+
+    expect($results)->toHaveCount(1);
+});
+
+it('can filter salary with dynamic array operator filter', function () {
+    TestModel::create(['salary' => 1000]);
+    TestModel::create(['salary' => 2000]);
+    TestModel::create(['salary' => 3000]);
+    TestModel::create(['salary' => 4000]);
+
+    $results = createQueryFromFilterRequest([
+            'salary' => '>1000,<4000',
+        ])
+        ->allowedFilters(AllowedFilter::operator('salary', FilterOperator::DYNAMIC))
         ->get();
 
     expect($results)->toHaveCount(2);

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -10,6 +10,7 @@ use Pest\Expectation;
 use function PHPUnit\Framework\assertObjectHasProperty;
 
 use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\Enums\FilterOperator;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 use Spatie\QueryBuilder\Filters\Filter as CustomFilter;
 use Spatie\QueryBuilder\Filters\Filter as FilterInterface;
@@ -657,4 +658,89 @@ it('can override the array value delimiter for single filters', function () {
         ->allowedFilters(AllowedFilter::exact('ref_id', 'name', true, '|'))
         ->get();
     expect($models->count())->toEqual(0);
+});
+
+it('can filter name with equal operator filter', function () {
+    TestModel::create(['name' => 'John Doe']);
+
+    $results = createQueryFromFilterRequest([
+            'name' => 'John Doe',
+        ])
+        ->allowedFilters(AllowedFilter::operator('name', FilterOperator::EQUAL))
+        ->get();
+
+    expect($results)->toHaveCount(1);
+});
+
+it('can filter name with not equal operator filter', function () {
+    TestModel::create(['name' => 'John Doe']);
+
+    $results = createQueryFromFilterRequest([
+            'name' => 'John Doe',
+        ])
+        ->allowedFilters(AllowedFilter::operator('name', FilterOperator::NOT_EQUAL))
+        ->get();
+
+    expect($results)->toHaveCount(5);
+});
+
+it('can filter name with greater than operator filter', function () {
+    TestModel::create(['salary' => 5000]);
+
+    $results = createQueryFromFilterRequest([
+            'salary' => 3000,
+        ])
+        ->allowedFilters(AllowedFilter::operator('salary', FilterOperator::GREATER_THAN))
+        ->get();
+
+    expect($results)->toHaveCount(1);
+});
+
+it('can filter name with less than operator filter', function () {
+    TestModel::create(['salary' => 5000]);
+
+    $results = createQueryFromFilterRequest([
+            'salary' => 7000,
+        ])
+        ->allowedFilters(AllowedFilter::operator('salary', FilterOperator::LESS_THAN))
+        ->get();
+
+    expect($results)->toHaveCount(1);
+});
+
+it('can filter name with greater than or equal operator filter', function () {
+    TestModel::create(['salary' => 5000]);
+
+    $results = createQueryFromFilterRequest([
+            'salary' => 3000,
+        ])
+        ->allowedFilters(AllowedFilter::operator('salary', FilterOperator::GREATER_THAN_OR_EQUAL))
+        ->get();
+
+    expect($results)->toHaveCount(1);
+});
+
+it('can filter name with less than or equal operator filter', function () {
+    TestModel::create(['salary' => 5000]);
+
+    $results = createQueryFromFilterRequest([
+            'salary' => 7000,
+        ])
+        ->allowedFilters(AllowedFilter::operator('salary', FilterOperator::LESS_THAN_OR_EQUAL))
+        ->get();
+
+    expect($results)->toHaveCount(1);
+});
+
+it('can filter array of names with equal operator filter', function () {
+    TestModel::create(['name' => 'John Doe']);
+    TestModel::create(['name' => 'Max Doe']);
+
+    $results = createQueryFromFilterRequest([
+            'name' => 'John Doe,Max Doe',
+        ])
+        ->allowedFilters(AllowedFilter::operator('name', FilterOperator::EQUAL, 'or'))
+        ->get();
+
+    expect($results)->toHaveCount(2);
 });

--- a/tests/RelationFilterTest.php
+++ b/tests/RelationFilterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\Enums\FilterOperator;
 use Spatie\QueryBuilder\Tests\TestClasses\Models\TestModel;
 
 beforeEach(function () {
@@ -114,4 +115,16 @@ it('can disable partial filtering based on related model properties', function (
         ->toSql();
 
     expect($sql)->toContain('LOWER(`relatedModels`.`name`) LIKE ?');
+});
+
+it('can disable operator filtering based on related model properties', function () {
+    $addRelationConstraint = false;
+
+    $sql = createQueryFromFilterRequest([
+            'relatedModels.name' => $this->models->first()->name,
+        ])
+        ->allowedFilters(AllowedFilter::operator('relatedModels.name', FilterOperator::EQUAL, 'and', null, $addRelationConstraint))
+        ->toSql();
+
+    expect($sql)->toContain('`relatedModels`.`name` = ?');
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -37,6 +37,7 @@ class TestCase extends Orchestra
             $table->increments('id');
             $table->timestamps();
             $table->string('name')->nullable();
+            $table->double('salary')->nullable();
             $table->boolean('is_visible')->default(true);
         });
 


### PR DESCRIPTION
Dear sir
I had been developed out of the box a method for filtering by operator.
for the example:
```
QueryBuilder::for(User::class)
->allowedFilters([
    AllowedFilter::operator('salary', FilterOperator::GREATER_THAN),
])
->get();
```
 > **_Note:_** I realized that there is some old test cases not working.