### PR TITLE
Fix ability to filter models by an array as filter value

### DIFF
--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -25,12 +25,12 @@ class FiltersPartial extends FiltersExact implements Filter
         $databaseDriver = $this->getDatabaseDriver($query);
 
         if (is_array($value)) {
-            if (count(array_filter($value, fn ($item) => empty($item))) === 0) {
+            if (count(array_filter($value, fn ($item) => strlen($item) > 0)) === 0) {
                 return $query;
             }
 
             $query->where(function (Builder $query) use ($databaseDriver, $value, $wrappedProperty) {
-                foreach (array_filter($value, fn ($item) => empty($item)) as $partialValue) {
+                foreach (array_filter($value, fn ($item) => strlen($item) > 0) as $partialValue) {
                     [$sql, $bindings] = $this->getWhereRawParameters($partialValue, $wrappedProperty, $databaseDriver);
                     $query->orWhereRaw($sql, $bindings);
                 }


### PR DESCRIPTION
In commit 9e68f80 filtering models by an array as a filter value was broken. This is confirmed by the tests that are failing: https://github.com/spatie/laravel-query-builder/actions/runs/9029978604/job/24813361498

This PR restores the original behaviour while keeping PHPstan happy.