### PR TITLE
[temp/ai test 🤖] Apply default sort when all provided sort parameters are invalid

### DIFF
--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -69,7 +69,7 @@ trait SortsQuery
 
                 $sort = $this->findSort($key);
 
-                if (!$sort) {
+                if (! $sort) {
                     // Apply default sort if no valid sorts are present in the request
                     $this->defaultSorts($this->allowedSorts->toArray());
                 } else {

--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -69,7 +69,12 @@ trait SortsQuery
 
                 $sort = $this->findSort($key);
 
-                $sort?->sort($this, $descending);
+                if (!$sort) {
+                    // Apply default sort if no valid sorts are present in the request
+                    $this->defaultSorts($this->allowedSorts->toArray());
+                } else {
+                    $sort->sort($this, $descending);
+                }
             });
     }
 

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -430,6 +430,21 @@ test('the default direction of an allow sort can be set', function () {
     $this->assertSortedDescending($sortedModels, 'name');
 });
 
+// Test for issue resolution
+it('applies default sort when all provided sort parameters are invalid', function () {
+    $request = new Request([
+        'sort' => 'invalid_column',
+    ]);
+
+    $sortedModels = QueryBuilder::for(TestModel::class, $request)
+        ->allowedSorts('name')
+        ->defaultSort('-name')
+        ->get();
+
+    // The default sort '-name' should be applied, resulting in models being sorted by 'name' in descending order.
+    $this->assertSortedDescending($sortedModels, 'name');
+});
+
 // Helpers
 function createQueryFromSortRequest(?string $sort = null): QueryBuilder
 {


### PR DESCRIPTION
Implements default sorting behavior when all provided sort parameters are invalid, ensuring the query builder falls back to a predefined default sort order.

- **Default Sort Application**: Modifies `addRequestedSortsToQuery` in `src/Concerns/SortsQuery.php` to apply the default sort when no valid sorts are present in the request. This ensures that if all provided sort parameters are invalid, the query builder will use the default sort order specified.
- **Test Coverage**: Adds a new test case in `tests/SortTest.php` to verify that the default sort is correctly applied when an invalid sort parameter is provided in the request. This test ensures the functionality works as expected and the default sorting is enforced in such scenarios.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spatie/laravel-query-builder/issues/942?shareId=9cd378ef-77aa-49b8-ae09-4627b6c4a777).