### PR TITLE
AllowedFilter should return static rather than self

### DIFF
--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -52,54 +52,54 @@ class AllowedFilter
         }
     }
 
-    public static function exact(string $name, ?string $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): self
+    public static function exact(string $name, ?string $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): static
     {
         static::setFilterArrayValueDelimiter($arrayValueDelimiter);
 
         return new static($name, new FiltersExact($addRelationConstraint), $internalName);
     }
 
-    public static function partial(string $name, $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): self
+    public static function partial(string $name, $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): static
     {
         static::setFilterArrayValueDelimiter($arrayValueDelimiter);
 
         return new static($name, new FiltersPartial($addRelationConstraint), $internalName);
     }
 
-    public static function beginsWithStrict(string $name, $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): self
+    public static function beginsWithStrict(string $name, $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): static
     {
         static::setFilterArrayValueDelimiter($arrayValueDelimiter);
 
         return new static($name, new FiltersBeginsWithStrict($addRelationConstraint), $internalName);
     }
 
-    public static function endsWithStrict(string $name, $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): self
+    public static function endsWithStrict(string $name, $internalName = null, bool $addRelationConstraint = true, string $arrayValueDelimiter = null): static
     {
         static::setFilterArrayValueDelimiter($arrayValueDelimiter);
 
         return new static($name, new FiltersEndsWithStrict($addRelationConstraint), $internalName);
     }
 
-    public static function scope(string $name, $internalName = null, string $arrayValueDelimiter = null): self
+    public static function scope(string $name, $internalName = null, string $arrayValueDelimiter = null): static
     {
         static::setFilterArrayValueDelimiter($arrayValueDelimiter);
 
         return new static($name, new FiltersScope(), $internalName);
     }
 
-    public static function callback(string $name, $callback, $internalName = null, string $arrayValueDelimiter = null): self
+    public static function callback(string $name, $callback, $internalName = null, string $arrayValueDelimiter = null): static
     {
         static::setFilterArrayValueDelimiter($arrayValueDelimiter);
 
         return new static($name, new FiltersCallback($callback), $internalName);
     }
 
-    public static function trashed(string $name = 'trashed', $internalName = null): self
+    public static function trashed(string $name = 'trashed', $internalName = null): static
     {
         return new static($name, new FiltersTrashed(), $internalName);
     }
 
-    public static function custom(string $name, Filter $filterClass, $internalName = null, string $arrayValueDelimiter = null): self
+    public static function custom(string $name, Filter $filterClass, $internalName = null, string $arrayValueDelimiter = null): static
     {
         static::setFilterArrayValueDelimiter($arrayValueDelimiter);
 
@@ -121,7 +121,7 @@ class AllowedFilter
         return $this->name === $filterName;
     }
 
-    public function ignore(...$values): self
+    public function ignore(...$values): static
     {
         $this->ignored = $this->ignored
             ->merge($values)
@@ -140,7 +140,7 @@ class AllowedFilter
         return $this->internalName;
     }
 
-    public function default($value): self
+    public function default($value): static
     {
         $this->hasDefault = true;
         $this->default = $value;
@@ -162,14 +162,14 @@ class AllowedFilter
         return $this->hasDefault;
     }
 
-    public function nullable(bool $nullable = true): self
+    public function nullable(bool $nullable = true): static
     {
         $this->nullable = $nullable;
 
         return $this;
     }
 
-    public function unsetDefault(): self
+    public function unsetDefault(): static
     {
         $this->hasDefault = false;
         unset($this->default);


### PR DESCRIPTION
Hey, everyone!

Thanks for this fantastic project. We find it very useful in our projects.

In our project, we want to extend the `AllowedFilter` class, and it seems nothing prevents us from doing that with the only exception - all methods return `self` and not `static`.

Please consider merging these changes.

I appreciate your work on this project!