### PR TITLE
Removed explicit escaping for pgsql driver in FilterPartial#maybeSpecifyEscapeChar. Fixes #941

### DIFF
--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -74,7 +74,7 @@ class FiltersPartial extends FiltersExact implements Filter
      */
     protected static function maybeSpecifyEscapeChar(string $driver): string
     {
-        if(! in_array($driver, ['sqlite','pgsql','sqlsrv'])) {
+        if (! in_array($driver, ['sqlite','pgsql','sqlsrv'])) {
             return '';
         }
 

--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -69,12 +69,12 @@ class FiltersPartial extends FiltersExact implements Filter
     }
 
     /**
-     * @param 'sqlite'|'pgsql'|'sqlsrc'|'mysql' $driver
+     * @param 'sqlite'|'pgsql'|'sqlsrc'|'mysql'|'mariadb' $driver
      * @return string
      */
     protected static function maybeSpecifyEscapeChar(string $driver): string
     {
-        if (! in_array($driver, ['sqlite','pgsql','sqlsrv'])) {
+        if (! in_array($driver, ['sqlite','sqlsrv'])) {
             return '';
         }
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -4,7 +4,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-
 use Pest\Expectation;
 
 use function PHPUnit\Framework\assertObjectHasProperty;

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -91,7 +91,7 @@ it('can filter a custom base query with select', function () {
 });
 
 it('specifies escape character in supported databases', function (string $dbDriver) {
-    if($dbDriver === 'mariadb' && !in_array('mariadb', DB::supportedDrivers())){
+    if ($dbDriver === 'mariadb' && ! in_array('mariadb', DB::supportedDrivers())) {
         $this->markTestSkipped('mariadb driver not supported in the installed version of illuminate/database dependency');
     }
 
@@ -103,7 +103,7 @@ it('specifies escape character in supported databases', function (string $dbDriv
     ]);
 
     DB::usingConnection($fakeConnection, function () use ($dbDriver) {
-        
+
         $request = new Request([
             'filter' => ['name' => 'to_find'],
         ]);

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -91,6 +91,10 @@ it('can filter a custom base query with select', function () {
 });
 
 it('specifies escape character in supported databases', function (string $dbDriver) {
+    if($dbDriver === 'mariadb' && !in_array('mariadb', DB::supportedDrivers())){
+        $this->markTestSkipped('mariadb driver not supported in the installed version of illuminate/database dependency');
+    }
+
     $fakeConnection = "test_{$dbDriver}";
 
     DB::connectUsing($fakeConnection, [
@@ -99,6 +103,7 @@ it('specifies escape character in supported databases', function (string $dbDriv
     ]);
 
     DB::usingConnection($fakeConnection, function () use ($dbDriver) {
+        
         $request = new Request([
             'filter' => ['name' => 'to_find'],
         ]);
@@ -107,10 +112,10 @@ it('specifies escape character in supported databases', function (string $dbDriv
             ->allowedFilters('name', 'id')
             ->toSql();
 
-        expect($queryBuilderSql)->when(in_array($dbDriver, ["sqlite","pgsql","sqlsrv"]), fn (Expectation $query) => $query->toContain("ESCAPE '\'"));
-        expect($queryBuilderSql)->when($dbDriver === 'mysql', fn (Expectation $query) => $query->not->toContain("ESCAPE '\'"));
+        expect($queryBuilderSql)->when(in_array($dbDriver, ["sqlite","sqlsrv"]), fn (Expectation $query) => $query->toContain("ESCAPE '\'"));
+        expect($queryBuilderSql)->when(in_array($dbDriver, ["mysql","mariadb", "pgsql"]), fn (Expectation $query) => $query->not->toContain("ESCAPE '\'"));
     });
-})->with(['sqlite', 'mysql', 'pgsql', 'sqlsrv']);
+})->with(['sqlite', 'mysql', 'pgsql', 'sqlsrv', 'mariadb']);
 
 it('can filter results based on the existence of a property in an array', function () {
     $results = createQueryFromFilterRequest([

--- a/tests/SortTest.php
+++ b/tests/SortTest.php
@@ -14,7 +14,6 @@ use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\Sorts\Sort as SortInterface;
 use Spatie\QueryBuilder\Sorts\SortsField;
 use Spatie\QueryBuilder\Tests\Concerns\AssertsCollectionSorting;
-
 use Spatie\QueryBuilder\Tests\TestClasses\Models\TestModel;
 
 uses(AssertsCollectionSorting::class);


### PR DESCRIPTION
As mentioned in the issue #941, my previous PR #927 causes the following error when using multiple partial filters in combination with Postgres: `SQLSTATE[HY093]: Invalid parameter number: parameter was not defined`

Before opening this PR, I investigated on why this may be happening, since from my previous tests (see attachment in PR #927), Postgres supports `ESCAPE` and the query result is the same with or without specifying it.

I've not been able to exactly identify the problem, but I managed to figure out it has something to do with the `\` char specifically.
In fact, if FilterPartials#maybeSpecifyEscapeChar was to be modified as follows, the `Invalid parameter number error` would not happen:
```
protected static function maybeSpecifyEscapeChar(string $driver): string
    {
        if(! in_array($driver, ['sqlite','sqlsrv', 'pgsql'])) { //DOES NOT include the removal of pgsql, that is the fix proposed in this PR
            return '';
        }

        return " ESCAPE 'ß'";  //previously: return " ESCAPE '\'";
    }
```
Basically, this code (so the code currently implemented, not modified if not for the ß char) would work just fine by just replacing `ESCAPE '\'` with `ESCAPE 'ß'` (I used `ß` as an example since it wouldn't collide with other special-meaning chars such as `*`, but it could be any char).

I guess this indicates that the problem does not live in the `maybeSpecifyEscapeChar `or in the package itself, but I suspect it resides in some Eloquent parsing.

On that regard, even if not related to the parsing of queries, I found a place in the Eloquent source (`vendor/laravel/framework/src/Illuminate/Database/Query/Grammars/Grammar.php function substituteBindingsIntoRawSql`), where expressions like `\'` are treated with special behaviors (tweaking that function, in fact, allowed me to parse the missing parameter in the `ddRawSql` while debuging). 
So my vague guess is that a similar behavior is influencing the parsing of the query when encountering `ESCAPE '\'`.

The proposed fix is really simple, I just removed `pgsql` from the drivers to explicitly escape, since the query results with or without `ESCAPE` are the same for that driver (see testing in PR#927 attachment)

In addition, in the `maybeSpecifyEscapeChar` phpdoc, I also added `'mariadb'` as a possible value for the `$driver` param, since L11 introduced that driver.
After all the changes I updated the tests and, since the `composer.json` of this package specify `"illuminate/database": "^10.0|^11.0"`, but mariadb is a valid driver only in v11, I used the following condition to run the mariadb test only if the driver is supported (skipped with relevant message otherwise):
```
//FilterTest.php line 93

if($dbDriver === 'mariadb' && !in_array('mariadb', DB::supportedDrivers())){
        $this->markTestSkipped('mariadb driver not supported in the installed version of illuminate/database dependency');
    }
```

This fix solves #941, allowing Postgres users to update the dependency and access the new features.

Hope this helps!
    
