### PR TITLE
Fixed IncludedCount.php

### DIFF
--- a/src/Includes/IncludedCount.php
+++ b/src/Includes/IncludedCount.php
@@ -9,6 +9,9 @@ class IncludedCount implements IncludeInterface
 {
     public function __invoke(Builder $query, string $count)
     {
-        $query->withCount(Str::before($count, config('query-builder.count_suffix', 'Count')));
+        $suffix = config('query-builder.count_suffix', 'Count');
+        $relation = Str::endsWith($count, $suffix) ? Str::beforeLast($count, $suffix) : $count;
+
+        $query->withCount($relation);
     }
 }


### PR DESCRIPTION
Fixed bug where the include count fails if a relation has the word `Count` in it. For example, it fails for `billingCountry` by removing the word `Country` and trying to load a `billing` relation.