### PR TITLE
Remove PHPUnit cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ composer.lock
 vendor
 .php_cs.cache
 coverage
+.phpunit.cache
 .phpunit.result.cache
 /.idea
 .php-cs-fixer.cache
-

--- a/.phpunit.cache/test-results
+++ b/.phpunit.cache/test-results
@@ -1,1 +1,0 @@
-{"version":"pest_2.35.1","defects":{"P\\Tests\\QueryBuilderTest::__pest_evaluable_it_has_the_right_phpstan_type":8},"times":{"P\\Tests\\QueryBuilderTest::__pest_evaluable_it_has_the_right_phpstan_type":0.027}}


### PR DESCRIPTION
Remove the `.phpunit.cache` directory and add it to the `.gitignore` file.