### PR TITLE
support nulls in belongsTo

### DIFF
--- a/src/Filters/FiltersBelongsTo.php
+++ b/src/Filters/FiltersBelongsTo.php
@@ -51,7 +51,7 @@ class FiltersBelongsTo implements Filter
     {
         return array_filter(
             $values,
-            fn ($v) => ! in_array($v, [null, 0, 'null', '0'], true)
+            fn ($v) => ! in_array($v, [null, 0, 'null', '0', ''], true)
         );
     }
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -15,6 +15,7 @@ use Spatie\QueryBuilder\Filters\Filter as CustomFilter;
 use Spatie\QueryBuilder\Filters\Filter as FilterInterface;
 use Spatie\QueryBuilder\Filters\FiltersExact;
 use Spatie\QueryBuilder\QueryBuilder;
+use Spatie\QueryBuilder\Tests\TestClasses\Models\NestedNullableRelatedModel;
 use Spatie\QueryBuilder\Tests\TestClasses\Models\NestedRelatedModel;
 use Spatie\QueryBuilder\Tests\TestClasses\Models\RelatedModel;
 use Spatie\QueryBuilder\Tests\TestClasses\Models\TestModel;
@@ -294,6 +295,31 @@ it('can filter results by belongs to', function () {
         ->get();
 
     expect($modelsResult)->toHaveCount(1);
+});
+
+it('can filter results by belongs to with null', function () {
+    $relatedModel = RelatedModel::create(['name' => 'John Related Doe', 'test_model_id' => 0]);
+    $nestedModel = NestedNullableRelatedModel::create(['name' => 'John Nested Doe', 'related_model_id' => $relatedModel->id]);
+    $nestedNullModel = NestedNullableRelatedModel::create(['name' => 'John Nested Doe']);
+
+    $modelsResult = createQueryFromFilterRequest(['relatedModel' => [null]], NestedNullableRelatedModel::class)
+        ->allowedFilters(AllowedFilter::belongsTo('relatedModel'))
+        ->get();
+
+    expect($modelsResult)->toHaveCount(1);
+
+    $modelsResult = createQueryFromFilterRequest(['relatedModel' => [0]], NestedNullableRelatedModel::class)
+        ->allowedFilters(AllowedFilter::belongsTo('relatedModel'))
+        ->get();
+
+    expect($modelsResult)->toHaveCount(1);
+
+
+    $modelsResult = createQueryFromFilterRequest(['relatedModel' => [$relatedModel->id, null]], NestedNullableRelatedModel::class)
+        ->allowedFilters(AllowedFilter::belongsTo('relatedModel'))
+        ->get();
+
+    expect($modelsResult)->toHaveCount(2);
 });
 
 it('can filter results by belongs to no match', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -71,6 +71,11 @@ class TestCase extends Orchestra
             $table->integer('related_model_id');
             $table->string('name');
         });
+        $app['db']->connection()->getSchemaBuilder()->create('nested_nullable_related_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('related_model_id')->nullable();
+            $table->string('name');
+        });
 
         $app['db']->connection()->getSchemaBuilder()->create('pivot_models', function (Blueprint $table) {
             $table->increments('id');

--- a/tests/TestClasses/Models/NestedNullableRelatedModel.php
+++ b/tests/TestClasses/Models/NestedNullableRelatedModel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\QueryBuilder\Tests\TestClasses\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NestedNullableRelatedModel extends Model
+{
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function relatedModel(): BelongsTo
+    {
+        return $this->belongsTo(RelatedModel::class);
+    }
+}


### PR DESCRIPTION
This is an improvement on PR #975.

The initial motivation is to support the search for belongsTo=null.

In these cases, it is necessary that the database, the column allows nulls, for example `$table->foreignId('user_id')->nullable()->constrained(table: 'users', indexName: 'posts_user_id');`.

In cases where it is detected that a nullable value is sent (`null`, `'null'`, `0`, `'0'`, `''`), then `whereNull($column)` is added to the query.

In this PR the code was simplified, instead of using `whereBelongsTo($collection, $relation)`, `whereIn($relation->getQualifiedForeignKeyName(), $values)` was used; where `$values` is no longer a collection but an array (with the ids).

In cases where a nullable value and an id are sent at the same time, for example `[null, 1, 3]`, both wheres are executed using the `OR` operator:
`$query->where(fn () => $q->orWhereNull($relationColumn)->orWhereIn($relationColumn, $values)`

---

As I said in #975 

> Unfortunately my English is not good and I couldn't write the documentation correctly.
If you think the PR is correct, could you help me with the documentation?

The documentation is pending.
[https://github.com/spatie/laravel-query-builder/blob/main/docs/features/filtering.md#belongsto-filters](https://github.com/spatie/laravel-query-builder/blob/main/docs/features/filtering.md#belongsto-filters)