### PR TITLE
Exclude `.github` folder and `.php_cs` from being included in composer installation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,10 +4,12 @@
 * text eol=lf
 
 # Ignore all test and documentation with "export-ignore".
+/.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore
+/.php_cs.dist.php   export-ignore
 /.scrutinizer.yml   export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore


### PR DESCRIPTION
This PR excludes the `.github` folder and the `.php_cs.dist.php` file from the composer installation:

<img width="262" alt="Screenshot 2025-02-18 at 5 27 48 PM" src="https://github.com/user-attachments/assets/62757fd9-f571-41c5-9e29-4bf36723a64d" />
