### PR TITLE
Enhance QueryBuilder with generics support for better type inference

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -14,7 +14,8 @@ use Spatie\QueryBuilder\Concerns\FiltersQuery;
 use Spatie\QueryBuilder\Concerns\SortsQuery;
 
 /**
- * @mixin EloquentBuilder
+ * @template TModel of Model
+ * @mixin EloquentBuilder<TModel>
  */
 class QueryBuilder implements ArrayAccess
 {
@@ -49,6 +50,9 @@ class QueryBuilder implements ArrayAccess
         return $this->subject;
     }
 
+    /**
+     * @return static<TModel>
+     */
     public static function for(
         EloquentBuilder|Relation|string $subject,
         ?Request $request = null
@@ -57,7 +61,10 @@ class QueryBuilder implements ArrayAccess
             $subject = $subject::query();
         }
 
-        return new static($subject, $request);
+        /** @var static<TModel> $queryBuilder */
+        $queryBuilder = new static($subject, $request);
+
+        return $queryBuilder;
     }
 
     public function __call($name, $arguments)

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -50,9 +50,6 @@ class QueryBuilder implements ArrayAccess
         return $this->subject;
     }
 
-    /**
-     * @return static<TModel>
-     */
     public static function for(
         EloquentBuilder|Relation|string $subject,
         ?Request $request = null
@@ -82,14 +79,9 @@ class QueryBuilder implements ArrayAccess
         return $result;
     }
 
-    /**
-     * @return static<TModel>
-     */
     public function clone(): static
     {
-        /** @var static<TModel> $cloned */
-        $cloned = clone $this;
-        return $cloned;
+        return clone $this;
     }
 
     public function __clone()

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -82,9 +82,14 @@ class QueryBuilder implements ArrayAccess
         return $result;
     }
 
+    /**
+     * @return static<TModel>
+     */
     public function clone(): static
     {
-        return clone $this;
+        /** @var static<TModel> $cloned */
+        $cloned = clone $this;
+        return $cloned;
     }
 
     public function __clone()


### PR DESCRIPTION
This pull request includes several changes to the `QueryBuilder` class in `src/QueryBuilder.php` to improve type safety and code clarity by adding template annotations and type hints. The most important changes include adding a template annotation to the class, updating the return type annotations for methods, and ensuring proper type casting.

When trying to specify the correct type in the following code:

```php
/**
     * @return LengthAwarePaginator<int, Client>
     */
    public function queryClients(Request $request): LengthAwarePaginator
    {
        /** @var QueryBuilder<Client> $queryBuilder */
        $queryBuilder = QueryBuilder::for(Client::class, $request);
...
```
Static analysis (PHPStan) generates the following error:
```
Method Modules\Client\Repositories\ClientRepository::queryClients() should return Illuminate\Pagination\LengthAwarePaginator<int, Modules\Client\Models\Client> but returns  
         Illuminate\Pagination\LengthAwarePaginator<int, Illuminate\Database\Eloquent\Model>.                                                                                         
         🪪  return.type
```
It happens because `Illuminate\Database\Eloquent\Builder` is a generic class:
```php
/**
 * @template TModel of \Illuminate\Database\Eloquent\Model
 */
class Builder implements BuilderContract
```

but `\Spatie\QueryBuilder\QueryBuilder` that specifies this class as a `@mixin` is not generic, so there is no way to specify a concrete type for the `TModel`.
This PR adds the ability to do this.