### PR TITLE
Add larastan and fix static analysis issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require-dev": {
         "ext-json": "*",
+        "larastan/larastan": "^3.3",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^7.0|^8.0|^10.0",
         "pestphp/pest": "^2.0|^3.7",

--- a/src/Filters/FiltersExact.php
+++ b/src/Filters/FiltersExact.php
@@ -67,6 +67,7 @@ class FiltersExact implements Filter
             ]);
 
         $query->whereHas($relation, function (Builder $query) use ($property, $value) {
+            /** @var Builder<TModelClass> $query */
             $this->relationConstraints[] = $property = $query->qualifyColumn($property);
 
             $this->__invoke($query, $value, $property);


### PR DESCRIPTION
This pull request includes updates to the `composer.json` file to add a new development dependency and an improvement to the type hinting in the `FiltersExact` class.

It looks like this project uses `larastan` for static analysis but there is no dev dependency for `larastan`.

Issue fixed:
```
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Filters/FiltersExact.php                                                                                                                                              
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  72     Parameter #1 $query of method Spatie\QueryBuilder\Filters\FiltersExact<TModelClass of Illuminate\Database\Eloquent\Model>::__invoke() expects                             
         Illuminate\Database\Eloquent\Builder<TModelClass of Illuminate\Database\Eloquent\Model>, Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model> given.  
         🪪  argument.type                                                                                                                                                         
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

```