### PR TITLE
Allow nested filters

### DIFF
--- a/src/Concerns/FiltersQuery.php
+++ b/src/Concerns/FiltersQuery.php
@@ -14,7 +14,7 @@ trait FiltersQuery
     {
         $filters = is_array($filters) ? $filters : func_get_args();
 
-        $this->allowedFilters = collect($filters)->map(function ($filter) {
+        $this->allowedFilters = collect($filters)->flatten(1)->map(function ($filter) {
             if ($filter instanceof AllowedFilter) {
                 return $filter;
             }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -479,6 +479,20 @@ it('can allow multiple filters as an array', function () {
     expect($results->pluck('id')->all())->toEqual([$model1->id, $model2->id]);
 });
 
+it('can allow multiple filters as nested array', function () {
+    $model1 = TestModel::create(['name' => 'abcdef']);
+    $model2 = TestModel::create(['name' => 'abcdef']);
+
+    $results = createQueryFromFilterRequest([
+        'name' => 'abc',
+    ])
+        ->allowedFilters([['name'], [AllowedFilter::exact('id')]])
+        ->get();
+
+    expect($results)->toHaveCount(2);
+    expect($results->pluck('id')->all())->toEqual([$model1->id, $model2->id]);
+});
+
 it('can filter by multiple filters', function () {
     $model1 = TestModel::create(['name' => 'abcdef']);
     $model2 = TestModel::create(['name' => 'abcdef']);


### PR DESCRIPTION
This PR adds the option to pass multiple arrays as filters. 
Just a small convenience which is also implemented for includes and fields