### PR TITLE
Improve QueryBuilder Generic Support

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,7 @@ parameters:
         - src/
         - config/
         - database/
+        - types/
 
     # Level 9 is the highest level
     level: 5

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -64,7 +64,7 @@ class QueryBuilder implements ArrayAccess
             $subject = $subject::query();
         }
 
-        /** @var static<TModel> $queryBuilder */
+        /** @var static<T> $queryBuilder */
         $queryBuilder = new static($subject, $request);
 
         return $queryBuilder;

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -51,8 +51,10 @@ class QueryBuilder implements ArrayAccess
     }
 
     /**
-     * @param EloquentBuilder<TModel>|Relation|class-string<TModel> $subject
-     * @return static<TModel>
+     * @template T of Model
+     *
+     * @param EloquentBuilder<T>|Relation|class-string<T> $subject
+     * @return static<T>
      */
     public static function for(
         EloquentBuilder|Relation|string $subject,

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -53,7 +53,7 @@ class QueryBuilder implements ArrayAccess
     /**
      * @template T of Model
      *
-     * @param EloquentBuilder<T>|Relation|class-string<T> $subject
+     * @param EloquentBuilder<T>|Relation<T, *, *>|class-string<T> $subject
      * @return static<T>
      */
     public static function for(

--- a/types/query-builder.php
+++ b/types/query-builder.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\QueryBuilder\QueryBuilder;
+use function PHPStan\Testing\assertType;
+
+class Book extends Model {
+    /**
+     * @return BelongsTo<Author, $this>
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(Author::class);
+    }
+}
+
+class Author extends Model {}
+
+assertType('Spatie\QueryBuilder\QueryBuilder<Book>', QueryBuilder::for(Book::class));
+assertType('Spatie\QueryBuilder\QueryBuilder<Book>', QueryBuilder::for(Book::query()));
+assertType('Spatie\QueryBuilder\QueryBuilder<Author>', QueryBuilder::for((new Book)->author()));


### PR DESCRIPTION
Hey, I believe the current implementation of generics on the QueryBuilder don't work as expected.

Currently, the following code:

```php
dumpType(QueryBuilder::for(User::class));
dumpType(QueryBuilder::for(Auth::user()->categories()));
dumpType(QueryBuilder::for(User::query()));
```

Produces the following:
```
Dumped type: Spatie\QueryBuilder\QueryBuilder<Illuminate\Database\Eloquent\Model>                                                                                           
Dumped type: Spatie\QueryBuilder\QueryBuilder<Illuminate\Database\Eloquent\Model>                                                                                           
Dumped type: Spatie\QueryBuilder\QueryBuilder<Illuminate\Database\Eloquent\Model>
```

In order to get this to the more precise:
``` 
Dumped type: Spatie\QueryBuilder\QueryBuilder<App\Models\User>                                                                                           
Dumped type: Spatie\QueryBuilder\QueryBuilder<App\Models\Category>                                                                                           
Dumped type: Spatie\QueryBuilder\QueryBuilder<App\Models\User>
```

I have implemented two changes. The first, is to use a new generic for the `for` method, as it is static. See examples: [using generic from class](https://phpstan.org/r/d10c9313-fc88-42d4-8224-75ef8171aef6) & [using generic from method ](https://phpstan.org/r/49b216aa-445f-4862-ad86-bc63bf32afc7). 

The second is to specify make use of this generic, when calling the method with a `Relation`. The `<T, *, *>` syntax means we're making use of the first generic, but don't care about the second and third (they can be anything - hence the asterisk).

I think ideally there would some type assertions for this functionality - I'd be open to adding some if desirable?