### PR TITLE
Make nullable parameter types explicit to avoid deprecation warnings

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -8,7 +8,7 @@ use Spatie\QueryBuilder\Tests\TestClasses\Models\TestModel;
 
 uses(TestCase::class)->in(__DIR__);
 
-function createQueryFromFilterRequest(array $filters, string $model = null): QueryBuilder
+function createQueryFromFilterRequest(array $filters, ?string $model = null): QueryBuilder
 {
     $model ??= TestModel::class;
 


### PR DESCRIPTION
# What’s been done

Just a quick tidy-up.  
PHP 8.1 started warning about implicitly nullable parameters, and PHP 8.4 is going to make them a hard error.  
So I’ve updated the function signatures to use `?type` syntax explicitly.

### Before:
```php
public function example(string $name = null)
```

### After:
```php
 public function example(?string $name = null)
```

This keeps us ahead of future PHP upgrades and makes the intent a bit clearer.
Shouldn’t affect any actual logic — purely a syntax-level fix.

Let me know if anything needs tweaking!