### PR TITLE
Make throwing exceptions on unknown filters optional

### DIFF
--- a/src/Concerns/FiltersQuery.php
+++ b/src/Concerns/FiltersQuery.php
@@ -10,6 +10,15 @@ trait FiltersQuery
 {
     protected Collection $allowedFilters;
 
+    protected bool $throwFilterExceptions = true;
+
+    public function throwFilterExceptions(bool $throw = true): static
+    {
+        $this->throwFilterExceptions = $throw;
+
+        return $this;
+    }
+
     public function allowedFilters($filters): static
     {
         $filters = is_array($filters) ? $filters : func_get_args();
@@ -60,7 +69,7 @@ trait FiltersQuery
 
     protected function ensureAllFiltersExist(): void
     {
-        if (config('query-builder.disable_invalid_filter_query_exception', false)) {
+        if (config('query-builder.disable_invalid_filter_query_exception', false) || ! $this->throwFilterExceptions) {
             return;
         }
 


### PR DESCRIPTION
Sometimes, I come across a situation where I want to apply filters on multiple queries in one request. Each of the filters in the request may only apply to one of the queries. In that case, an `InvalidFilterQuery` will be thrown because not all filters are valid for all queries.

I'm aware that this can be disabled with the `query-builder.disable_invalid_filter_query_exception` config variable, but I'd like to keep throwing exceptions in most cases, but when one of these special cases arise, disable it on the `QueryBuilder` level.

This should keep the current default functionality as-is and not introduce any breaking changes. If this is not suitable for the project or you may have any other questions, please let me know.