### PR TITLE
Update reference to Laravel Pagination docs

### DIFF
--- a/docs/advanced-usage/pagination.md
+++ b/docs/advanced-usage/pagination.md
@@ -3,7 +3,7 @@ title: Pagination
 weight: 2
 ---
 
-This package doesn't provide any methods to help you paginate responses. However as documented above you can use Laravel's default [`paginate()` method](https://laravel.com/docs/5.5/pagination).
+This package doesn't provide any methods to help you paginate responses. However as documented above you can use Laravel's default [`paginate()` method](https://laravel.com/docs/12.x/pagination).
 
 If you want to completely adhere to the JSON API specification you can also use our own [spatie/json-api-paginate](https://github.com/spatie/laravel-json-api-paginate)!
 


### PR DESCRIPTION
This link to Laravel's Pagination docs links to an older version of Laravel. Updating this link will make it easier for readers of the documentation to see the most up-to-date docs.