### PR TITLE
Update documentation in the config

### DIFF
--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -53,11 +53,11 @@ return [
     /*
      * By default, the package expects relationship names to be snake case plural when using fields[relationship].
      * For example, fetching the id and name for a userOwner relation would look like this:
-     * GET /users?fields[user_owner]=id,name
+     * GET /users?include=userOwner&fields[user_owners]=id,name
      *
      * Set this to `false` if you don't want that and keep the requested relationship names as-is and allows you to
      * request the fields using a camelCase relationship name:
-     * GET /users?fields[userOwner]=id,name
+     * GET /users?include=userOwner&fields[userOwner]=id,name
      */
     'convert_relation_names_to_snake_case_plural' => true,
 


### PR DESCRIPTION
This pull request updates the documentation comments in the `config/query-builder.php` file to clarify how relationship names should be used in API requests, especially when specifying included relationships and field selections.

Syncs docblock comments with what's in the `docs/installation-setup.md`.