### PR TITLE
fix: handle empty delimiters gracefully in query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-query-builder` will be documented in this file
 
+## Unreleased
+
+- Fix empty global delimiter causing a `ValueError` in query parameter parsing (#1055)
+
 ## 7.1.0 - 2026-03-29
 
 - Add per-filter delimiter support via fluent `delimiter()` method on `AllowedFilter`

--- a/docs/advanced-usage/multi-value-delimiter.md
+++ b/docs/advanced-usage/multi-value-delimiter.md
@@ -21,6 +21,16 @@ With this configuration, a request like `GET /api/endpoint?filter[voltage]=12,4V
 
 __Note that this applies to ALL values for filters, includes and sorts.__
 
+To disable splitting entirely for all parameters, set the global delimiter to an empty string:
+
+```php
+// config/query-builder.php
+
+return [
+    'delimiter' => '',
+];
+```
+
 ## Per filter delimiter
 
 You can override the delimiter for a specific filter using the `delimiter()` method. This is useful when a filter value may contain the default delimiter character.

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -13,7 +13,7 @@ class QueryBuilderRequest extends Request
         return static::createFrom($request, new static());
     }
 
-    protected function maybeExplode(mixed $parts): array
+    protected function toParameterArray(mixed $parts): array
     {
         if (is_array($parts)) {
             return $parts;
@@ -38,7 +38,7 @@ class QueryBuilderRequest extends Request
 
         $includeParts = $this->getRequestData($includeParameterName);
 
-        return collect($this->maybeExplode($includeParts))->filter();
+        return collect($this->toParameterArray($includeParts))->filter();
     }
 
     public function appends(): Collection
@@ -47,7 +47,7 @@ class QueryBuilderRequest extends Request
 
         $appendParts = $this->getRequestData($appendParameterName);
 
-        return collect($this->maybeExplode($appendParts))->filter();
+        return collect($this->toParameterArray($appendParts))->filter();
     }
 
     public function fields(): Collection
@@ -55,7 +55,7 @@ class QueryBuilderRequest extends Request
         $fieldsParameterName = config('query-builder.parameters.fields', 'fields');
         $fieldsData = $this->getRequestData($fieldsParameterName);
 
-        $fieldsPerTable = collect($this->maybeExplode($fieldsData));
+        $fieldsPerTable = collect($this->toParameterArray($fieldsData));
 
         if ($fieldsPerTable->isEmpty()) {
             return collect();
@@ -74,7 +74,7 @@ class QueryBuilderRequest extends Request
 
             $tableFields = array_map(function (string $field) {
                 return Str::afterLast($field, '.');
-            }, $this->maybeExplode($tableFields));
+            }, $this->toParameterArray($tableFields));
 
             $fields[$model] = array_merge($fields[$model], $tableFields);
         });
@@ -88,7 +88,7 @@ class QueryBuilderRequest extends Request
 
         $sortParts = $this->getRequestData($sortParameterName);
 
-        return collect($this->maybeExplode($sortParts))->filter();
+        return collect($this->toParameterArray($sortParts))->filter();
     }
 
     public function filters(): Collection

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -13,17 +13,32 @@ class QueryBuilderRequest extends Request
         return static::createFrom($request, new static());
     }
 
+    protected function maybeExplode(mixed $parts): array
+    {
+        if (is_array($parts)) {
+            return $parts;
+        }
+
+        if (is_null($parts) || $parts === '') {
+            return [];
+        }
+
+        $delimiter = $this->delimiter();
+
+        if ($delimiter === '') {
+            return [(string) $parts];
+        }
+
+        return explode($delimiter, (string) $parts);
+    }
+
     public function includes(): Collection
     {
         $includeParameterName = config('query-builder.parameters.include', 'include');
 
         $includeParts = $this->getRequestData($includeParameterName);
 
-        if (is_string($includeParts)) {
-            $includeParts = explode($this->delimiter(), $includeParts);
-        }
-
-        return collect($includeParts)->filter();
+        return collect($this->maybeExplode($includeParts))->filter();
     }
 
     public function appends(): Collection
@@ -32,11 +47,7 @@ class QueryBuilderRequest extends Request
 
         $appendParts = $this->getRequestData($appendParameterName);
 
-        if (! is_array($appendParts) && ! is_null($appendParts)) {
-            $appendParts = explode($this->delimiter(), $appendParts);
-        }
-
-        return collect($appendParts)->filter();
+        return collect($this->maybeExplode($appendParts))->filter();
     }
 
     public function fields(): Collection
@@ -44,7 +55,7 @@ class QueryBuilderRequest extends Request
         $fieldsParameterName = config('query-builder.parameters.fields', 'fields');
         $fieldsData = $this->getRequestData($fieldsParameterName);
 
-        $fieldsPerTable = collect(is_string($fieldsData) ? explode($this->delimiter(), $fieldsData) : $fieldsData);
+        $fieldsPerTable = collect($this->maybeExplode($fieldsData));
 
         if ($fieldsPerTable->isEmpty()) {
             return collect();
@@ -63,7 +74,7 @@ class QueryBuilderRequest extends Request
 
             $tableFields = array_map(function (string $field) {
                 return Str::afterLast($field, '.');
-            }, explode($this->delimiter(), $tableFields));
+            }, $this->maybeExplode($tableFields));
 
             $fields[$model] = array_merge($fields[$model], $tableFields);
         });
@@ -77,11 +88,7 @@ class QueryBuilderRequest extends Request
 
         $sortParts = $this->getRequestData($sortParameterName);
 
-        if (is_string($sortParts)) {
-            $sortParts = explode($this->delimiter(), $sortParts);
-        }
-
-        return collect($sortParts)->filter();
+        return collect($this->maybeExplode($sortParts))->filter();
     }
 
     public function filters(): Collection

--- a/tests/QueryBuilderRequestTest.php
+++ b/tests/QueryBuilderRequestTest.php
@@ -435,21 +435,21 @@ it('returns raw filter values without splitting by delimiter', function () {
     expect($request->filters()->toArray())->toEqual($expected);
 });
 
-it("handles empty delimiter gracefully", function() {
+it('handles empty delimiter gracefully', function () {
     config()->set('query-builder.delimiter', '');
 
     $request = new QueryBuilderRequest([
-        'include' => 'foo',
-        'append' => 'bar',
-        'fields' => ['table'=>['foo', 'bar']],
+        'include' => 'foo,bar',
+        'append' => 'baz,qux',
+        'fields' => ['table' => ['foo', 'bar']],
         'filter' => [
             'foo' => 'values',
         ],
-        'sort' => 'bar',
+        'sort' => 'bar,-created_at',
     ]);
 
-    expect($request->includes()->toArray())->toEqual(['foo']);
-    expect($request->appends()->toArray())->toEqual(['bar']);
+    expect($request->includes()->toArray())->toEqual(['foo,bar']);
+    expect($request->appends()->toArray())->toEqual(['baz,qux']);
     expect($request->fields()->toArray())->toEqual(['table' => ['foo', 'bar']]);
-    expect($request->sorts()->toArray())->toEqual(['bar']);
+    expect($request->sorts()->toArray())->toEqual(['bar,-created_at']);
 });

--- a/tests/QueryBuilderRequestTest.php
+++ b/tests/QueryBuilderRequestTest.php
@@ -435,7 +435,7 @@ it('returns raw filter values without splitting by delimiter', function () {
     expect($request->filters()->toArray())->toEqual($expected);
 });
 
-it('handles empty delimiter gracefully', function () {
+it('does not split values when the global delimiter is empty', function () {
     config()->set('query-builder.delimiter', '');
 
     $request = new QueryBuilderRequest([
@@ -452,4 +452,41 @@ it('handles empty delimiter gracefully', function () {
     expect($request->appends()->toArray())->toEqual(['baz,qux']);
     expect($request->fields()->toArray())->toEqual(['table' => ['foo', 'bar']]);
     expect($request->sorts()->toArray())->toEqual(['bar,-created_at']);
+});
+
+it('does not split string fields when the global delimiter is empty', function () {
+    config()->set('query-builder.delimiter', '');
+
+    $request = new QueryBuilderRequest([
+        'fields' => [
+            'table' => 'name,email',
+        ],
+    ]);
+
+    expect($request->fields()->toArray())->toEqual(['table' => ['name,email']]);
+});
+
+it('returns empty collections for omitted parameters when the global delimiter is empty', function () {
+    config()->set('query-builder.delimiter', '');
+
+    $request = new QueryBuilderRequest();
+
+    expect($request->includes())->toBeEmpty();
+    expect($request->appends())->toBeEmpty();
+    expect($request->sorts())->toBeEmpty();
+    expect($request->fields())->toBeEmpty();
+});
+
+it('returns empty collections for empty string parameters when the global delimiter is empty', function () {
+    config()->set('query-builder.delimiter', '');
+
+    $request = new QueryBuilderRequest([
+        'include' => '',
+        'append' => '',
+        'sort' => '',
+    ]);
+
+    expect($request->includes())->toBeEmpty();
+    expect($request->appends())->toBeEmpty();
+    expect($request->sorts())->toBeEmpty();
 });

--- a/tests/QueryBuilderRequestTest.php
+++ b/tests/QueryBuilderRequestTest.php
@@ -434,3 +434,22 @@ it('returns raw filter values without splitting by delimiter', function () {
 
     expect($request->filters()->toArray())->toEqual($expected);
 });
+
+it("handles empty delimiter gracefully", function() {
+    config()->set('query-builder.delimiter', '');
+
+    $request = new QueryBuilderRequest([
+        'include' => 'foo',
+        'append' => 'bar',
+        'fields' => ['table'=>['foo', 'bar']],
+        'filter' => [
+            'foo' => 'values',
+        ],
+        'sort' => 'bar',
+    ]);
+
+    expect($request->includes()->toArray())->toEqual(['foo']);
+    expect($request->appends()->toArray())->toEqual(['bar']);
+    expect($request->fields()->toArray())->toEqual(['table' => ['foo', 'bar']]);
+    expect($request->sorts()->toArray())->toEqual(['bar']);
+});


### PR DESCRIPTION
Using the new `delimiter` config value, setting an empty string can be used to disable the delimiter functionality. However, the empty delimiter currently causes a `ValueException` in the `QueryBuilderRequest` if sort, includes, appends or fields are used.

This PR 
- Introduces a protected maybeExplode method to handle the conversion of request data (string, array, or null) into a consistent array format.
- Adds a test case to ensure parameters are handled correctly empty string delimiters are in use.