### PR TITLE
Add support for disabling global filter value splitting

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,6 +1,6 @@
 name: Check & fix styling
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
     php-cs-fixer:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,6 +5,10 @@ on:
         paths:
             - '**.php'
             - 'phpstan.neon.dist'
+    pull_request:
+        paths:
+            - '**.php'
+            - 'phpstan.neon.dist'
 
 jobs:
     phpstan:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: run-tests
 
-on: push
+on: [push, pull_request]
 
 jobs:
   test:

--- a/config/query-builder.php
+++ b/config/query-builder.php
@@ -23,6 +23,11 @@ return [
     'delimiter' => ',',
 
     /*
+     * Whether filter values should be split by the configured delimiter.
+     */
+    'filter_value_splitting_enabled' => true,
+
+    /*
      * Related model aggregates are included using the relationship name suffixed with these strings.
      * For example: GET /users?include=postsCount or GET /users?include=postsViewsSum
      */

--- a/docs/advanced-usage/multi-value-delimiter.md
+++ b/docs/advanced-usage/multi-value-delimiter.md
@@ -31,6 +31,16 @@ return [
 ];
 ```
 
+If you need only filter values to stay intact globally, you can disable filter delimiter splitting in config:
+
+```php
+// config/query-builder.php
+
+'filter_value_splitting_enabled' => false,
+```
+
+This only affects filter values. Includes, sorts, fields, and appends will continue using the configured global delimiter. The default value is `true`. 
+
 ## Per filter delimiter
 
 You can override the delimiter for a specific filter using the `delimiter()` method. This is useful when a filter value may contain the default delimiter character.

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -47,6 +47,11 @@ return [
     'delimiter' => ',',
 
     /*
+     * Whether filter values should be split by the configured delimiter.
+     */
+    'filter_value_splitting_enabled' => true,
+
+    /*
      * Related model aggregates are included using the relationship name suffixed with these strings.
      * For example: GET /users?include=postsCount or GET /users?include=postsViewsSum
      */

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -193,6 +193,10 @@ class AllowedFilter
 
     protected function splitFilterValue(mixed $value): mixed
     {
+        if ($this->filterValueSplittingDisabled()) {
+            return $value;
+        }
+
         $delimiter = $this->getDelimiter();
 
         if ($delimiter === '') {
@@ -219,5 +223,11 @@ class AllowedFilter
         }
 
         return ! $this->ignored->contains($value) ? $value : null;
+    }
+
+    protected function filterValueSplittingDisabled(): bool
+    {
+        return \is_null($this->arrayValueDelimiter)
+            && ! config('query-builder.filter_value_splitting_enabled', true);
     }
 }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -855,6 +855,53 @@ it('can disable delimiter splitting with an empty string delimiter', function ()
     expect($models->first()->name)->toEqual('value_one,value_two');
 });
 
+it('can disable filter delimiter splitting globally via config', function () {
+    config()->set('query-builder.filter_value_splitting_enabled', false);
+
+    TestModel::create(['name' => 'value_one,value_two']);
+    TestModel::create(['name' => 'value_one']);
+    TestModel::create(['name' => 'value_two']);
+
+    $models = createQueryFromFilterRequest([
+        'name' => 'value_one,value_two',
+    ])
+        ->allowedFilters(AllowedFilter::exact('name'))
+        ->get();
+
+    expect($models->sole()->name)->toEqual('value_one,value_two');
+});
+
+it('can re-enable filter delimiter splitting globally', function () {
+    config()->set('query-builder.filter_value_splitting_enabled', false);
+    config()->set('query-builder.filter_value_splitting_enabled', true);
+
+    TestModel::create(['name' => 'value_one']);
+    TestModel::create(['name' => 'value_two']);
+
+    $models = createQueryFromFilterRequest([
+        'name' => 'value_one,value_two',
+    ])
+        ->allowedFilters(AllowedFilter::exact('name'))
+        ->get();
+
+    expect($models->count())->toEqual(2);
+});
+
+it('uses a per-filter delimiter when the global filter delimiter is disabled', function () {
+    config()->set('query-builder.filter_value_splitting_enabled', false);
+
+    TestModel::create(['name' => 'value_one']);
+    TestModel::create(['name' => 'value_two']);
+
+    $models = createQueryFromFilterRequest([
+        'name' => 'value_one|value_two',
+    ])
+        ->allowedFilters(AllowedFilter::exact('name')->delimiter('|'))
+        ->get();
+
+    expect($models->count())->toEqual(2);
+});
+
 it('uses the config delimiter as the default for filters', function () {
     config()->set('query-builder.delimiter', '|');
 

--- a/tests/QueryBuilderRequestTest.php
+++ b/tests/QueryBuilderRequestTest.php
@@ -423,6 +423,18 @@ it('takes custom delimiters for splitting request parameters', function () {
     expect($request->includes()->toArray())->toEqual(['foo', 'bar', 'baz']);
 });
 
+it('does not affect include splitting when the filter delimiter is disabled', function () {
+    config()->set('query-builder.filter_value_splitting_enabled', false);
+
+    $request = new QueryBuilderRequest([
+        'include' => 'foo,bar,baz',
+    ]);
+
+    expect(config()->get('query-builder.delimiter'))->toEqual(',');
+
+    expect($request->includes()->toArray())->toEqual(['foo', 'bar', 'baz']);
+});
+
 it('returns raw filter values without splitting by delimiter', function () {
     $request = new QueryBuilderRequest([
         'filter' => [


### PR DESCRIPTION
This PR brings back behavior that existed before the delimiter rewrite.

In older versions, you could effectively disable global filter value splitting with:

```php
QueryBuilderRequest::setFilterArrayValueDelimiter('');
```

With the recent major release of v7, that stopped being possible. Delimiter handling moved to config and became universal so it became impossible to turn filter-only splitting off globally.

This change restores that capability with config:
```php
// config/query-builder.php
'filter_value_splitting_enabled' => false,
```

#### A few comments
- the default stays true
- this only affects filter values
- per-filter **->delimiter()** still overrides the global setting


#### Why this matters:

Some apps need raw filter values because the delimiter character is part of the actual value. We used to support that, then v7 dropped it. This brings that capability back without reintroducing the old static delimiter API.