### PR TITLE
Fix PHPStan errors on main

### DIFF
--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -36,7 +36,7 @@ class FiltersPartial implements Filter
             $query->where(function (Builder $query) use ($value, $wrappedProperty, $databaseDriver) {
                 foreach (array_filter($value, fn ($item) => $item != '') as $partialValue) {
                     [$sql, $bindings] = $this->getWhereRawParameters($partialValue, $wrappedProperty, $databaseDriver);
-                    $query->orWhereRaw($sql, $bindings);
+                    $query->orWhereRaw($sql, $bindings); /** @phpstan-ignore-line */
                 }
             });
 

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -13,6 +13,9 @@ class QueryBuilderRequest extends Request
         return static::createFrom($request, new static());
     }
 
+    /**
+     * @return array<mixed>
+     */
     protected function toParameterArray(mixed $parts): array
     {
         if (is_array($parts)) {


### PR DESCRIPTION
## Summary

- Adds `@return array<mixed>` PHPDoc to `QueryBuilderRequest::toParameterArray()` so PHPStan knows the iterable value type.
- Adds `@phpstan-ignore-line` to the `orWhereRaw` call in `FiltersPartial`; the SQL template is safely constructed from wrapped column names, but PHPStan wants a `literal-string` which cannot be produced at runtime.

Both errors were failing on main since before #1056.