### PR TITLE
Improve PHPStan - Part 1

### DIFF
--- a/database/factories/AppendModelFactory.php
+++ b/database/factories/AppendModelFactory.php
@@ -5,6 +5,9 @@ namespace Spatie\QueryBuilder\Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Spatie\QueryBuilder\Tests\TestClasses\Models\AppendModel;
 
+/**
+ * @extends Factory<AppendModel>
+ */
 class AppendModelFactory extends Factory
 {
     protected $model = AppendModel::class;

--- a/database/factories/SoftDeleteModelFactory.php
+++ b/database/factories/SoftDeleteModelFactory.php
@@ -5,6 +5,9 @@ namespace Spatie\QueryBuilder\Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Spatie\QueryBuilder\Tests\TestClasses\Models\SoftDeleteModel;
 
+/**
+ * @extends Factory<SoftDeleteModel>
+ */
 class SoftDeleteModelFactory extends Factory
 {
     protected $model = SoftDeleteModel::class;

--- a/database/factories/TestModelFactory.php
+++ b/database/factories/TestModelFactory.php
@@ -5,6 +5,9 @@ namespace Spatie\QueryBuilder\Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Spatie\QueryBuilder\Tests\TestClasses\Models\TestModel;
 
+/**
+ * @extends Factory<TestModel>
+ */
 class TestModelFactory extends Factory
 {
     protected $model = TestModel::class;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,12 +25,6 @@ parameters:
 			path: src/AllowedFilter.php
 
 		-
-			message: '#^Property Spatie\\QueryBuilder\\AllowedFilter\:\:\$ignored with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/AllowedFilter.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\AllowedInclude\:\:__construct\(\) has parameter \$includeClass with generic interface Spatie\\QueryBuilder\\Includes\\IncludeInterface but does not specify its types\: TModelClass$#'
 			identifier: missingType.generics
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,24 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Class Spatie\\QueryBuilder\\Database\\Factories\\AppendModelFactory extends generic class Illuminate\\Database\\Eloquent\\Factories\\Factory but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: database/factories/AppendModelFactory.php
-
-		-
-			message: '#^Class Spatie\\QueryBuilder\\Database\\Factories\\SoftDeleteModelFactory extends generic class Illuminate\\Database\\Eloquent\\Factories\\Factory but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: database/factories/SoftDeleteModelFactory.php
-
-		-
-			message: '#^Class Spatie\\QueryBuilder\\Database\\Factories\\TestModelFactory extends generic class Illuminate\\Database\\Eloquent\\Factories\\Factory but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: database/factories/TestModelFactory.php
-
-		-
 			message: '#^Cannot unset property Spatie\\QueryBuilder\\AllowedFilter\:\:\$default because it might have hooks in a subclass\.$#'
 			identifier: unset.possiblyHookedProperty
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -497,21 +497,3 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/QueryBuilderServiceProvider.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Sorts\\Sort\:\:__invoke\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Sorts/Sort.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Sorts\\SortsCallback\:\:__invoke\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Sorts/SortsCallback.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Sorts\\SortsField\:\:__invoke\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Sorts/SortsField.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -567,13 +567,13 @@ parameters:
 		-
 			message: '#^Unable to resolve the template type TKey in call to function collect$#'
 			identifier: argument.templateType
-			count: 4
+			count: 1
 			path: src/QueryBuilderRequest.php
 
 		-
 			message: '#^Unable to resolve the template type TValue in call to function collect$#'
 			identifier: argument.templateType
-			count: 4
+			count: 1
 			path: src/QueryBuilderRequest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,18 +49,6 @@ parameters:
 			path: src/AllowedSort.php
 
 		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidAppendQuery\:\:__construct\(\) has parameter \$allowedAppends with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidAppendQuery.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidAppendQuery\:\:__construct\(\) has parameter \$appendsNotAllowed with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidAppendQuery.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidAppendQuery\:\:appendsNotAllowed\(\) has parameter \$allowedAppends with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,12 +19,6 @@ parameters:
 			path: src/AllowedInclude.php
 
 		-
-			message: '#^Method Spatie\\QueryBuilder\\AllowedSort\:\:sort\(\) has parameter \$query with generic class Spatie\\QueryBuilder\\QueryBuilder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/AllowedSort.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidFieldQuery\:\:__construct\(\) has parameter \$allowedFields with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1
@@ -77,30 +71,6 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: src/Exceptions/InvalidIncludeQuery.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidSortQuery\:\:__construct\(\) has parameter \$allowedSorts with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidSortQuery.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidSortQuery\:\:__construct\(\) has parameter \$unknownSorts with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidSortQuery.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidSortQuery\:\:sortsNotAllowed\(\) has parameter \$allowedSorts with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidSortQuery.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidSortQuery\:\:sortsNotAllowed\(\) has parameter \$unknownSorts with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidSortQuery.php
 
 		-
 			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\UnknownIncludedFieldsQuery\:\:__construct\(\) has parameter \$unknownFields with no value type specified in iterable type array\.$#'
@@ -332,25 +302,7 @@ parameters:
 			path: src/QueryBuilder.php
 
 		-
-			message: '#^Unable to resolve the template type TKey in call to function collect$#'
-			identifier: argument.templateType
-			count: 2
-			path: src/QueryBuilder.php
-
-		-
-			message: '#^Unable to resolve the template type TValue in call to function collect$#'
-			identifier: argument.templateType
-			count: 2
-			path: src/QueryBuilder.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\QueryBuilderRequest\:\:appends\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/QueryBuilderRequest.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\QueryBuilderRequest\:\:fields\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/QueryBuilderRequest.php
@@ -358,24 +310,6 @@ parameters:
 		-
 			message: '#^Method Spatie\\QueryBuilder\\QueryBuilderRequest\:\:includes\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
-			count: 1
-			path: src/QueryBuilderRequest.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\QueryBuilderRequest\:\:sorts\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/QueryBuilderRequest.php
-
-		-
-			message: '#^Unable to resolve the template type TKey in call to function collect$#'
-			identifier: argument.templateType
-			count: 1
-			path: src/QueryBuilderRequest.php
-
-		-
-			message: '#^Unable to resolve the template type TValue in call to function collect$#'
-			identifier: argument.templateType
 			count: 1
 			path: src/QueryBuilderRequest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -313,8 +313,3 @@ parameters:
 			count: 1
 			path: src/QueryBuilderRequest.php
 
-		-
-			message: '#^Method Spatie\\QueryBuilder\\QueryBuilderServiceProvider\:\:provides\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/QueryBuilderServiceProvider.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,18 +49,6 @@ parameters:
 			path: src/AllowedSort.php
 
 		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidAppendQuery\:\:appendsNotAllowed\(\) has parameter \$allowedAppends with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidAppendQuery.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidAppendQuery\:\:appendsNotAllowed\(\) has parameter \$appendsNotAllowed with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidAppendQuery.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidFieldQuery\:\:__construct\(\) has parameter \$allowedFields with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Cannot unset property Spatie\\QueryBuilder\\AllowedFilter\:\:\$default because it might have hooks in a subclass\.$#'
-			identifier: unset.possiblyHookedProperty
-			count: 1
-			path: src/AllowedFilter.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\AllowedFilter\:\:__construct\(\) has parameter \$filterClass with generic interface Spatie\\QueryBuilder\\Filters\\Filter but does not specify its types\: TModelClass$#'
 			identifier: missingType.generics
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,12 +49,6 @@ parameters:
 			path: src/AllowedSort.php
 
 		-
-			message: '#^Method Spatie\\QueryBuilder\\Enums\\FilterOperator\:\:isDynamic\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Enums/FilterOperator.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidAppendQuery\:\:__construct\(\) has parameter \$allowedAppends with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -73,30 +73,6 @@ parameters:
 			path: src/Exceptions/InvalidFieldQuery.php
 
 		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidFilterQuery\:\:__construct\(\) has parameter \$allowedFilters with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidFilterQuery.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidFilterQuery\:\:__construct\(\) has parameter \$unknownFilters with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidFilterQuery.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidFilterQuery\:\:filtersNotAllowed\(\) has parameter \$allowedFilters with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidFilterQuery.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidFilterQuery\:\:filtersNotAllowed\(\) has parameter \$unknownFilters with generic class Illuminate\\Support\\Collection but does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Exceptions/InvalidFilterQuery.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\Exceptions\\InvalidFilterValue\:\:make\(\) has parameter \$value with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -457,12 +433,6 @@ parameters:
 			path: src/QueryBuilder.php
 
 		-
-			message: '#^Property Spatie\\QueryBuilder\\QueryBuilder\:\:\$allowedFilters with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/QueryBuilder.php
-
-		-
 			message: '#^Property Spatie\\QueryBuilder\\QueryBuilder\:\:\$allowedIncludes with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1
@@ -494,12 +464,6 @@ parameters:
 
 		-
 			message: '#^Method Spatie\\QueryBuilder\\QueryBuilderRequest\:\:fields\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/QueryBuilderRequest.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\QueryBuilderRequest\:\:filters\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/QueryBuilderRequest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,12 +25,6 @@ parameters:
 			path: src/AllowedFilter.php
 
 		-
-			message: '#^Method Spatie\\QueryBuilder\\AllowedFilter\:\:getIgnored\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/AllowedFilter.php
-
-		-
 			message: '#^Property Spatie\\QueryBuilder\\AllowedFilter\:\:\$ignored with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,30 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Method Spatie\\QueryBuilder\\AllowedFilter\:\:__construct\(\) has parameter \$filterClass with generic interface Spatie\\QueryBuilder\\Filters\\Filter but does not specify its types\: TModelClass$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/AllowedFilter.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\AllowedFilter\:\:custom\(\) has parameter \$filterClass with generic interface Spatie\\QueryBuilder\\Filters\\Filter but does not specify its types\: TModelClass$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/AllowedFilter.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\AllowedFilter\:\:filter\(\) has parameter \$query with generic class Spatie\\QueryBuilder\\QueryBuilder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/AllowedFilter.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\AllowedFilter\:\:getFilterClass\(\) return type with generic interface Spatie\\QueryBuilder\\Filters\\Filter does not specify its types\: TModelClass$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/AllowedFilter.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\AllowedInclude\:\:__construct\(\) has parameter \$includeClass with generic interface Spatie\\QueryBuilder\\Includes\\IncludeInterface but does not specify its types\: TModelClass$#'
 			identifier: missingType.generics
 			count: 1
@@ -139,22 +115,10 @@ parameters:
 			path: src/Exceptions/UnknownIncludedFieldsQuery.php
 
 		-
-			message: '#^Class Spatie\\QueryBuilder\\Filters\\FiltersBeginsWith extends generic class Spatie\\QueryBuilder\\Filters\\FiltersPartial but does not specify its types\: TModelClass$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Filters/FiltersBeginsWith.php
-
-		-
 			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersBeginsWith\:\:getWhereRawParameters\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Filters/FiltersBeginsWith.php
-
-		-
-			message: '#^Class Spatie\\QueryBuilder\\Filters\\FiltersEndsWith extends generic class Spatie\\QueryBuilder\\Filters\\FiltersPartial but does not specify its types\: TModelClass$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Filters/FiltersEndsWith.php
 
 		-
 			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersEndsWith\:\:getWhereRawParameters\(\) return type has no value type specified in iterable type array\.$#'
@@ -163,25 +127,7 @@ parameters:
 			path: src/Filters/FiltersEndsWith.php
 
 		-
-			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersExact\:\:isRelationProperty\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Filters/FiltersExact.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersExact\:\:withRelationConstraint\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Filters/FiltersExact.php
-
-		-
 			message: '#^Parameter \#1 \$keys of method Illuminate\\Support\\Collection\<int,string\>\:\:except\(\) expects array\<int\>\|Illuminate\\Support\\Enumerable\<\(int\|string\), int\>\|string, int\<\-1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Filters/FiltersExact.php
-
-		-
-			message: '#^Parameter \#1 \$query of method Spatie\\QueryBuilder\\Filters\\FiltersExact\<TModelClass of Illuminate\\Database\\Eloquent\\Model\>\:\:__invoke\(\) expects Illuminate\\Database\\Eloquent\\Builder\<TModelClass of Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Filters/FiltersExact.php
@@ -193,25 +139,7 @@ parameters:
 			path: src/Filters/FiltersExact.php
 
 		-
-			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersOperator\:\:isRelationProperty\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Filters/FiltersOperator.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersOperator\:\:withRelationConstraint\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Filters/FiltersOperator.php
-
-		-
 			message: '#^Parameter \#1 \$keys of method Illuminate\\Support\\Collection\<int,string\>\:\:except\(\) expects array\<int\>\|Illuminate\\Support\\Enumerable\<\(int\|string\), int\>\|string, int\<\-1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Filters/FiltersOperator.php
-
-		-
-			message: '#^Parameter \#1 \$query of method Spatie\\QueryBuilder\\Filters\\FiltersOperator\<TModelClass of Illuminate\\Database\\Eloquent\\Model\>\:\:__invoke\(\) expects Illuminate\\Database\\Eloquent\\Builder\<TModelClass of Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Filters/FiltersOperator.php
@@ -235,25 +163,7 @@ parameters:
 			path: src/Filters/FiltersPartial.php
 
 		-
-			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersPartial\:\:isRelationProperty\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Filters/FiltersPartial.php
-
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersPartial\:\:withRelationConstraint\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Filters/FiltersPartial.php
-
-		-
 			message: '#^Parameter \#1 \$keys of method Illuminate\\Support\\Collection\<int,string\>\:\:except\(\) expects array\<int\>\|Illuminate\\Support\\Enumerable\<\(int\|string\), int\>\|string, int\<\-1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Filters/FiltersPartial.php
-
-		-
-			message: '#^Parameter \#1 \$query of method Spatie\\QueryBuilder\\Filters\\FiltersPartial\<TModelClass of Illuminate\\Database\\Eloquent\\Model\>\:\:__invoke\(\) expects Illuminate\\Database\\Eloquent\\Builder\<TModelClass of Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Filters/FiltersPartial.php
@@ -282,11 +192,6 @@ parameters:
 			count: 1
 			path: src/Filters/FiltersScope.php
 
-		-
-			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersScope\:\:resolveParameters\(\) has parameter \$query with generic class Illuminate\\Database\\Eloquent\\Builder but does not specify its types\: TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Filters/FiltersScope.php
 
 		-
 			message: '#^Method Spatie\\QueryBuilder\\Filters\\FiltersScope\:\:resolveParameters\(\) has parameter \$values with no value type specified in iterable type array\.$#'
@@ -299,24 +204,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Filters/FiltersScope.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<TModelClass of Illuminate\\Database\\Eloquent\\Model\>\:\:onlyTrashed\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Filters/FiltersTrashed.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<TModelClass of Illuminate\\Database\\Eloquent\\Model\>\:\:withTrashed\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Filters/FiltersTrashed.php
-
-		-
-			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\<TModelClass of Illuminate\\Database\\Eloquent\\Model\>\:\:withoutTrashed\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Filters/FiltersTrashed.php
 
 		-
 			message: '#^Class Spatie\\QueryBuilder\\Includes\\IncludedCallback implements generic interface Spatie\\QueryBuilder\\Includes\\IncludeInterface but does not specify its types\: TModelClass$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,6 @@ parameters:
 
     checkModelProperties: true
     checkOctaneCompatibility: true
-    reportUnmatchedIgnoredErrors: false
     noUnnecessaryCollectionCall: true
     checkNullables: true
     treatPhpDocTypesAsCertain: false

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -83,7 +83,7 @@ class AllowedFilter
 
     public function getDelimiter(): string
     {
-        return $this->arrayValueDelimiter ?? config('query-builder.delimiter', ',');
+        return $this->arrayValueDelimiter ?? config()->string('query-builder.delimiter', ',');
     }
 
     public static function exact(string $name, ?string $internalName = null, bool $addRelationConstraint = true): static
@@ -270,7 +270,7 @@ class AllowedFilter
 
     protected function filterValueSplittingDisabled(): bool
     {
-        return \is_null($this->arrayValueDelimiter)
-            && ! config('query-builder.filter_value_splitting_enabled', true);
+        return null === $this->arrayValueDelimiter
+            && ! config()->boolean('query-builder.filter_value_splitting_enabled', true);
     }
 }

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -19,6 +19,11 @@ use Spatie\QueryBuilder\Filters\FiltersPartial;
 use Spatie\QueryBuilder\Filters\FiltersScope;
 use Spatie\QueryBuilder\Filters\FiltersTrashed;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @phpstan-import-type FiltersCallbackSchema from FiltersCallback
+ */
 class AllowedFilter
 {
     /**
@@ -41,6 +46,7 @@ class AllowedFilter
 
     /**
      * @param non-empty-string $name
+     * @param Filter<TModel> $filterClass
      * @param ?non-empty-string $internalName
      */
     public function __construct(
@@ -53,13 +59,16 @@ class AllowedFilter
         $this->internalName = $internalName ?? $name;
     }
 
+    /**
+     * @param QueryBuilder<TModel> $query
+     */
     public function filter(QueryBuilder $query, mixed $value): void
     {
         $this->applyTo($query->getEloquentBuilder(), $value);
     }
 
     /**
-     * @param  Builder<Model>  $builder
+     * @param  Builder<TModel>  $builder
      */
     public function applyTo(Builder $builder, mixed $value): void
     {
@@ -86,46 +95,108 @@ class AllowedFilter
         return $this->arrayValueDelimiter ?? config()->string('query-builder.delimiter', ',');
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function exact(string $name, ?string $internalName = null, bool $addRelationConstraint = true): static
     {
-        return new static($name, new FiltersExact($addRelationConstraint), $internalName);
+        /** @var FiltersExact<TModel> */
+        $filter = new FiltersExact($addRelationConstraint);
+
+        return new static($name, $filter, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function partial(string $name, ?string $internalName = null, bool $addRelationConstraint = true): static
     {
-        return new static($name, new FiltersPartial($addRelationConstraint), $internalName);
+        /** @var FiltersPartial<TModel> */
+        $filter = new FiltersPartial($addRelationConstraint);
+
+        return new static($name, $filter, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function beginsWith(string $name, ?string $internalName = null, bool $addRelationConstraint = true): static
     {
-        return new static($name, new FiltersBeginsWith($addRelationConstraint), $internalName);
+        /** @var FiltersBeginsWith<TModel> */
+        $filter = new FiltersBeginsWith($addRelationConstraint);
+
+        return new static($name, $filter, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function endsWith(string $name, ?string $internalName = null, bool $addRelationConstraint = true): static
     {
-        return new static($name, new FiltersEndsWith($addRelationConstraint), $internalName);
+        /** @var FiltersEndsWith<TModel> */
+        $filter = new FiltersEndsWith($addRelationConstraint);
+
+        return new static($name, $filter, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function belongsTo(string $name, ?string $internalName = null): static
     {
-        return new static($name, new FiltersBelongsTo, $internalName);
+        /** @var FiltersEndsWith<TModel> */
+        $filter = new FiltersBelongsTo;
+
+        return new static($name, $filter, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function scope(string $name, ?string $internalName = null): static
     {
-        return new static($name, new FiltersScope, $internalName);
+        /** @var FiltersScope<TModel> */
+        $filter = new FiltersScope;
+
+        return new static($name, $filter, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param FiltersCallbackSchema $callback
+     * @param ?non-empty-string $internalName
+     */
     public static function callback(string $name, callable $callback, ?string $internalName = null): static
     {
-        return new static($name, new FiltersCallback($callback), $internalName);
+        /** @var FiltersCallback<TModel> */
+        $filter = new FiltersCallback($callback);
+
+        return new static($name, $filter, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function trashed(string $name = 'trashed', ?string $internalName = null): static
     {
-        return new static($name, new FiltersTrashed, $internalName);
+        /** @var FiltersTrashed<TModel> */
+        $filter = new FiltersTrashed;
+
+        return new static($name, $filter, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param Filter<TModel> $filterClass
+     * @param ?non-empty-string $internalName
+     */
     public static function custom(string $name, Filter $filterClass, ?string $internalName = null): static
     {
         return new static($name, $filterClass, $internalName);
@@ -138,25 +209,39 @@ class AllowedFilter
         ?string $internalName = null,
         bool $addRelationConstraint = true,
     ): static {
-        return new static($name, new FiltersOperator($addRelationConstraint, $filterOperator, $boolean), $internalName);
+        /** @var FiltersOperator<TModel> */
+        $filter = new FiltersOperator($addRelationConstraint, $filterOperator, $boolean);
+
+        return new static($name, $filter, $internalName);
     }
 
     /**
-     * @param  AllowedFilter[]  $members
+     * @param non-empty-string $name
+     * @param  AllowedFilter<TModel>[]  $members
      */
     public static function groupOr(string $name, array $members): static
     {
-        return new static($name, new FiltersGroup('or', $members));
+        /** @var FiltersGroup<TModel> */
+        $filter = new FiltersGroup('or', $members);
+
+        return new static($name, $filter);
     }
 
     /**
-     * @param  AllowedFilter[]  $members
+     * @param non-empty-string $name
+     * @param  AllowedFilter<TModel>[]  $members
      */
     public static function groupAnd(string $name, array $members): static
     {
-        return new static($name, new FiltersGroup('and', $members));
+        /** @var FiltersGroup<TModel> */
+        $filter = new FiltersGroup('and', $members);
+
+        return new static($name, $filter);
     }
 
+    /**
+     * @return Filter<TModel>
+     */
     public function getFilterClass(): Filter
     {
         return $this->filterClass;
@@ -260,9 +345,7 @@ class AllowedFilter
     protected function resolveValueForFiltering(mixed $value): mixed
     {
         if (is_array($value)) {
-            $remainingProperties = array_map([$this, 'resolveValueForFiltering'], $value);
-
-            return ! empty($remainingProperties) ? $remainingProperties : null;
+            return array_map([$this, 'resolveValueForFiltering'], $value) ?: null;
         }
 
         return ! $this->ignored->contains($value) ? $value : null;

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -213,7 +213,7 @@ class AllowedFilter
     public function unsetDefault(): static
     {
         $this->hasDefault = false;
-        unset($this->default);
+        $this->default = null;
 
         return $this;
     }

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -176,7 +176,7 @@ class AllowedFilter
      */
     public function getIgnored(): array
     {
-        return $this->ignored->toArray();
+        return $this->ignored->all();
     }
 
     public function getInternalName(): string

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -171,6 +171,9 @@ class AllowedFilter
         return $this;
     }
 
+    /**
+     * @return array<array-key, mixed>
+     */
     public function getIgnored(): array
     {
         return $this->ignored->toArray();

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -23,6 +23,9 @@ class AllowedFilter
 {
     protected string $internalName;
 
+    /**
+     * @var \Illuminate\Support\Collection<array-key,mixed>
+     */
     protected Collection $ignored;
 
     protected mixed $default = null;

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -21,10 +21,13 @@ use Spatie\QueryBuilder\Filters\FiltersTrashed;
 
 class AllowedFilter
 {
+    /**
+     * @var non-empty-string
+     */
     protected string $internalName;
 
     /**
-     * @var \Illuminate\Support\Collection<array-key,mixed>
+     * @var \Illuminate\Support\Collection<int,mixed>
      */
     protected Collection $ignored;
 
@@ -36,6 +39,10 @@ class AllowedFilter
 
     protected ?string $arrayValueDelimiter = null;
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public function __construct(
         protected string $name,
         protected Filter $filterClass,
@@ -155,6 +162,9 @@ class AllowedFilter
         return $this->filterClass;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getName(): string
     {
         return $this->name;

--- a/src/AllowedInclude.php
+++ b/src/AllowedInclude.php
@@ -13,10 +13,20 @@ use Spatie\QueryBuilder\Includes\IncludedRelationship;
 use Spatie\QueryBuilder\Includes\IncludedSum;
 use Spatie\QueryBuilder\Includes\IncludeInterface;
 
+/**
+ * @phpstan-import-type IncludedCallbackSchema from IncludedCallback
+ */
 class AllowedInclude
 {
+    /**
+     * @var non-empty-string
+     */
     protected string $internalName;
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public function __construct(
         protected string $name,
         protected IncludeInterface $includeClass,
@@ -25,46 +35,89 @@ class AllowedInclude
         $this->internalName = $internalName ?? $this->name;
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function relationship(string $name, ?string $internalName = null): static
     {
         return new static($name, new IncludedRelationship, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function count(string $name, ?string $internalName = null, ?Closure $constraint = null): static
     {
         return new static($name, new IncludedCount($constraint), $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function exists(string $name, ?string $internalName = null, ?Closure $constraint = null): static
     {
         return new static($name, new IncludedExists($constraint), $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $relation
+     * @param ?non-empty-string $internalName
+     */
     public static function min(string $name, string $relation, string $column, ?string $internalName = null, ?Closure $constraint = null): static
     {
         return new static($name, new IncludedMin($relation, $column, $constraint), $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $relation
+     * @param ?non-empty-string $internalName
+     */
     public static function max(string $name, string $relation, string $column, ?string $internalName = null, ?Closure $constraint = null): static
     {
         return new static($name, new IncludedMax($relation, $column, $constraint), $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $relation
+     * @param non-empty-string $column
+     * @param ?non-empty-string $internalName
+     */
     public static function sum(string $name, string $relation, string $column, ?string $internalName = null, ?Closure $constraint = null): static
     {
         return new static($name, new IncludedSum($relation, $column, $constraint), $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param non-empty-string $relation
+     * @param non-empty-string $column
+     * @param ?non-empty-string $internalName
+     */
     public static function avg(string $name, string $relation, string $column, ?string $internalName = null, ?Closure $constraint = null): static
     {
         return new static($name, new IncludedAvg($relation, $column, $constraint), $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param IncludedCallbackSchema $callback
+     * @param ?non-empty-string $internalName
+     */
     public static function callback(string $name, Closure $callback, ?string $internalName = null): static
     {
         return new static($name, new IncludedCallback($callback), $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function custom(string $name, IncludeInterface $includeClass, ?string $internalName = null): static
     {
         return new static($name, $includeClass, $internalName);
@@ -81,6 +134,9 @@ class AllowedInclude
         ($this->includeClass)($query->getEloquentBuilder(), $this->internalName);
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getName(): string
     {
         return $this->name;

--- a/src/AllowedSort.php
+++ b/src/AllowedSort.php
@@ -46,6 +46,9 @@ class AllowedSort
         return str_starts_with($name, '-') ? SortDirection::Descending : SortDirection::Ascending;
     }
 
+    /**
+     * @param QueryBuilder<TModel> $query
+     */
     public function sort(QueryBuilder $query, ?bool $descending = null): void
     {
         $descending = $descending ?? ($this->defaultDirection === SortDirection::Descending);

--- a/src/AllowedSort.php
+++ b/src/AllowedSort.php
@@ -7,12 +7,25 @@ use Spatie\QueryBuilder\Sorts\Sort;
 use Spatie\QueryBuilder\Sorts\SortsCallback;
 use Spatie\QueryBuilder\Sorts\SortsField;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @phpstan-import-type SortsCallbackSchema from SortsCallback
+ */
 class AllowedSort
 {
     protected SortDirection $defaultDirection;
 
+    /**
+     * @var non-empty-string
+     */
     protected string $internalName;
 
+    /**
+     * @param non-empty-string $name
+     * @param Sort<TModel> $sortClass
+     * @param ?non-empty-string $internalName
+     */
     public function __construct(
         protected string $name,
         protected Sort $sortClass,
@@ -25,6 +38,9 @@ class AllowedSort
         $this->internalName = $internalName ?? $this->name;
     }
 
+    /**
+     * @param non-empty-string $name
+     */
     public static function parseSortDirection(string $name): SortDirection
     {
         return str_starts_with($name, '-') ? SortDirection::Descending : SortDirection::Ascending;
@@ -34,24 +50,50 @@ class AllowedSort
     {
         $descending = $descending ?? ($this->defaultDirection === SortDirection::Descending);
 
-        ($this->sortClass)($query->getEloquentBuilder(), $descending, $this->internalName);
+        /** @var \Illuminate\Database\Eloquent\Builder<TModel> */
+        $builder = $query->getEloquentBuilder();
+
+        ($this->sortClass)($builder, $descending, $this->internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param ?non-empty-string $internalName
+     */
     public static function field(string $name, ?string $internalName = null): static
     {
-        return new static($name, new SortsField, $internalName);
+        /** @var SortsField<TModel> */
+        $sorter = new SortsField;
+
+        return new static($name, $sorter, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param Sort<TModel> $sortClass
+     * @param ?non-empty-string $internalName
+     */
     public static function custom(string $name, Sort $sortClass, ?string $internalName = null): static
     {
         return new static($name, $sortClass, $internalName);
     }
 
+    /**
+     * @param non-empty-string $name
+     * @param SortsCallbackSchema $callback
+     * @param ?non-empty-string $internalName
+     */
     public static function callback(string $name, callable $callback, ?string $internalName = null): static
     {
-        return new static($name, new SortsCallback($callback), $internalName);
+        /** @var SortsCallback<TModel> */
+        $sorter = new SortsCallback($callback);
+
+        return new static($name, $sorter, $internalName);
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getName(): string
     {
         return $this->name;
@@ -62,6 +104,9 @@ class AllowedSort
         return $this->name === $sortName;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getInternalName(): string
     {
         return $this->internalName;

--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -31,7 +31,7 @@ trait AddsFieldsToQuery
 
         $fields = $this->request->fields();
 
-        if (! $fields->isEmpty() && config('query-builder.convert_field_names_to_snake_case', false)) {
+        if (! $fields->isEmpty() && config()->boolean('query-builder.convert_field_names_to_snake_case', false)) {
             $fields = $fields->mapWithKeys(fn ($fields, $table) => [$table => collect($fields)->map(fn ($field) => Str::snake($field))->toArray()]);
         }
 
@@ -55,7 +55,7 @@ trait AddsFieldsToQuery
     public function getRequestedFieldsForRelatedTable(string $relation, ?string $tableName = null): array
     {
         $possibleRelatedNames = [
-            config('query-builder.convert_relation_names_to_snake_case_plural', true)
+            config()->boolean('query-builder.convert_relation_names_to_snake_case_plural', true)
                 ? Str::plural(Str::snake($relation))
                 : $relation,
         ];
@@ -73,7 +73,7 @@ trait AddsFieldsToQuery
         $possibleRelatedNames = array_filter($possibleRelatedNames);
 
         $fields = $this->request->fields()
-            ->mapWithKeys(fn ($fields, $table) => [$table => collect($fields)->map(fn ($field) => config('query-builder.convert_field_names_to_snake_case', false) ? Str::snake($field) : $field)])
+            ->mapWithKeys(fn ($fields, $table) => [$table => collect($fields)->map(fn ($field) => config()->boolean('query-builder.convert_field_names_to_snake_case', false) ? Str::snake($field) : $field)])
             ->filter(fn ($value, $table) => in_array($table, $possibleRelatedNames))
             ->first();
 

--- a/src/Concerns/AddsFieldsToQuery.php
+++ b/src/Concerns/AddsFieldsToQuery.php
@@ -11,6 +11,9 @@ trait AddsFieldsToQuery
 {
     protected ?Collection $allowedFields = null;
 
+    /**
+     * @param non-empty-string $fields
+     */
     public function allowedFields(string ...$fields): static
     {
         $this->allowedFields = collect($fields)

--- a/src/Concerns/AddsIncludesToQuery.php
+++ b/src/Concerns/AddsIncludesToQuery.php
@@ -36,8 +36,8 @@ trait AddsIncludesToQuery
 
     protected function generateIncludesFromString(string $include): array
     {
-        $countSuffix = config('query-builder.suffixes.count', 'Count');
-        $existsSuffix = config('query-builder.suffixes.exists', 'Exists');
+        $countSuffix = config()->string('query-builder.suffixes.count', 'Count');
+        $existsSuffix = config()->string('query-builder.suffixes.exists', 'Exists');
 
         if (Str::endsWith($include, $countSuffix)) {
             return [AllowedInclude::count($include)];
@@ -80,7 +80,8 @@ trait AddsIncludesToQuery
 
     protected function ensureAllIncludesExist(): void
     {
-        if (config('query-builder.disable_invalid_include_query_exception', false)) {
+        $shouldSkip = config()->boolean('query-builder.disable_invalid_include_query_exception', false);
+        if ($shouldSkip) {
             return;
         }
 
@@ -97,7 +98,8 @@ trait AddsIncludesToQuery
 
     protected function filterNonExistingIncludes(Collection $includes): Collection
     {
-        if (! config('query-builder.disable_invalid_include_query_exception', false)) {
+        $shouldCalculateDiff = config()->boolean('query-builder.disable_invalid_include_query_exception', false);
+        if (! $shouldCalculateDiff) {
             return $includes;
         }
 

--- a/src/Concerns/FiltersQuery.php
+++ b/src/Concerns/FiltersQuery.php
@@ -8,8 +8,14 @@ use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 
 trait FiltersQuery
 {
+    /**
+     * @var Collection<array-key, AllowedFilter>
+     */
     protected Collection $allowedFilters;
 
+    /**
+     * @param \Spatie\QueryBuilder\AllowedFilter|non-empty-string $filters
+     */
     public function allowedFilters(AllowedFilter|string ...$filters): static
     {
         $this->allowedFilters = collect($filters)->map(function ($filter) {

--- a/src/Concerns/FiltersQuery.php
+++ b/src/Concerns/FiltersQuery.php
@@ -6,15 +6,18 @@ use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterQuery;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 trait FiltersQuery
 {
     /**
-     * @var Collection<array-key, AllowedFilter>
+     * @var Collection<array-key, AllowedFilter<TModel>>
      */
     protected Collection $allowedFilters;
 
     /**
-     * @param \Spatie\QueryBuilder\AllowedFilter|non-empty-string $filters
+     * @param \Spatie\QueryBuilder\AllowedFilter<TModel>|non-empty-string $filters
      */
     public function allowedFilters(AllowedFilter|string ...$filters): static
     {
@@ -23,6 +26,9 @@ trait FiltersQuery
                 return $filter;
             }
 
+            /**
+             * @var AllowedFilter<TModel>
+             */
             return AllowedFilter::partial($filter);
         });
 
@@ -49,12 +55,18 @@ trait FiltersQuery
         });
     }
 
+    /**
+     * @return AllowedFilter<TModel>
+     */
     protected function findFilter(string $property): ?AllowedFilter
     {
         return $this->allowedFilters
             ->first(fn (AllowedFilter $filter) => $filter->isForFilter($property));
     }
 
+    /**
+     * @param AllowedFilter<TModel> $allowedFilter
+     */
     protected function isFilterRequested(AllowedFilter $allowedFilter): bool
     {
         return $this->request->filters()->has($allowedFilter->getName());

--- a/src/Concerns/FiltersQuery.php
+++ b/src/Concerns/FiltersQuery.php
@@ -62,7 +62,9 @@ trait FiltersQuery
 
     protected function ensureAllFiltersExist(): void
     {
-        if (config('query-builder.disable_invalid_filter_query_exception', false)) {
+        $shouldSkip = config()->boolean('query-builder.disable_invalid_filter_query_exception', false);
+
+        if ($shouldSkip) {
             return;
         }
 

--- a/src/Concerns/FiltersQuery.php
+++ b/src/Concerns/FiltersQuery.php
@@ -18,7 +18,7 @@ trait FiltersQuery
      */
     public function allowedFilters(AllowedFilter|string ...$filters): static
     {
-        $this->allowedFilters = collect($filters)->map(function ($filter) {
+        $this->allowedFilters = collect($filters)->map(static function ($filter) {
             if ($filter instanceof AllowedFilter) {
                 return $filter;
             }
@@ -68,7 +68,9 @@ trait FiltersQuery
 
         $filterNames = $this->request->filters()->keys();
 
-        $allowedFilterNames = $this->allowedFilters->map(fn (AllowedFilter $allowedFilter) => $allowedFilter->getName());
+        $allowedFilterNames = $this->allowedFilters->map(
+            static fn (AllowedFilter $allowedFilter) => $allowedFilter->getName()
+        );
 
         $diff = $filterNames->diff($allowedFilterNames);
 

--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -6,10 +6,16 @@ use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\AllowedSort;
 use Spatie\QueryBuilder\Exceptions\InvalidSortQuery;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 trait SortsQuery
 {
     protected Collection $allowedSorts;
 
+    /**
+     * @param AllowedSort<TModel>|non-empty-string $sorts
+     */
     public function allowedSorts(AllowedSort|string ...$sorts): static
     {
         $this->allowedSorts = collect($sorts)->map(function ($sort) {
@@ -27,11 +33,17 @@ trait SortsQuery
         return $this;
     }
 
+    /**
+     * @param AllowedSort<TModel>|non-empty-string $sorts
+     */
     public function defaultSort(AllowedSort|string ...$sorts): static
     {
         return $this->defaultSorts(...$sorts);
     }
 
+    /**
+     * @param AllowedSort<TModel>|non-empty-string $sorts
+     */
     public function defaultSorts(AllowedSort|string ...$sorts): static
     {
         if ($this->request->sorts()->isNotEmpty()) {
@@ -65,6 +77,9 @@ trait SortsQuery
             });
     }
 
+    /**
+     * @return ?AllowedSort<TModel>
+     */
     protected function findSort(string $property): ?AllowedSort
     {
         return $this->allowedSorts

--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -93,7 +93,10 @@ trait SortsQuery
             return;
         }
 
-        $requestedSortNames = $this->request->sorts()->map(fn (string $sort) => ltrim($sort, '-'));
+        /** @var Collection<int,non-empty-string> */
+        $requestedSortNames = $this->request->sorts()->map(
+            static fn (string $sort) => ltrim($sort, '-')
+        );
 
         $allowedSortNames = $this->allowedSorts->map(fn (AllowedSort $sort) => $sort->getName());
 

--- a/src/Concerns/SortsQuery.php
+++ b/src/Concerns/SortsQuery.php
@@ -73,7 +73,8 @@ trait SortsQuery
 
     protected function ensureAllSortsExist(): void
     {
-        if (config('query-builder.disable_invalid_sort_query_exception', false)) {
+        $shouldSkip = config()->boolean('query-builder.disable_invalid_sort_query_exception', false);
+        if ($shouldSkip) {
             return;
         }
 

--- a/src/Enums/FilterOperator.php
+++ b/src/Enums/FilterOperator.php
@@ -12,7 +12,7 @@ enum FilterOperator: string
     case GREATER_THAN_OR_EQUAL = '>=';
     case NOT_EQUAL = '<>';
 
-    public function isDynamic()
+    public function isDynamic(): bool
     {
         return $this === self::DYNAMIC;
     }

--- a/src/Exceptions/InvalidAppendQuery.php
+++ b/src/Exceptions/InvalidAppendQuery.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Collection;
 class InvalidAppendQuery extends InvalidQuery
 {
     /**
-     * @param Collection<array-key,non-empty-string> $appendsNotAllowed
-     * @param Collection<array-key,non-empty-string> $allowedAppends
+     * @param Collection<int,non-empty-string> $appendsNotAllowed
+     * @param Collection<int,non-empty-string> $allowedAppends
      */
     public function __construct(
         public Collection $appendsNotAllowed,
@@ -23,8 +23,8 @@ class InvalidAppendQuery extends InvalidQuery
     }
 
     /**
-     * @param Collection<array-key,non-empty-string> $appendsNotAllowed
-     * @param Collection<array-key,non-empty-string> $allowedAppends
+     * @param Collection<int,non-empty-string> $appendsNotAllowed
+     * @param Collection<int,non-empty-string> $allowedAppends
      */
     public static function appendsNotAllowed(Collection $appendsNotAllowed, Collection $allowedAppends): static
     {

--- a/src/Exceptions/InvalidAppendQuery.php
+++ b/src/Exceptions/InvalidAppendQuery.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Collection;
 
 class InvalidAppendQuery extends InvalidQuery
 {
+    /**
+     * @param Collection<array-key,non-empty-string> $appendsNotAllowed
+     * @param Collection<array-key,non-empty-string> $allowedAppends
+     */
     public function __construct(
         public Collection $appendsNotAllowed,
         public Collection $allowedAppends

--- a/src/Exceptions/InvalidAppendQuery.php
+++ b/src/Exceptions/InvalidAppendQuery.php
@@ -22,6 +22,10 @@ class InvalidAppendQuery extends InvalidQuery
         parent::__construct(Response::HTTP_BAD_REQUEST, $message);
     }
 
+    /**
+     * @param Collection<array-key,non-empty-string> $appendsNotAllowed
+     * @param Collection<array-key,non-empty-string> $allowedAppends
+     */
     public static function appendsNotAllowed(Collection $appendsNotAllowed, Collection $allowedAppends): static
     {
         return new static(...func_get_args());

--- a/src/Exceptions/InvalidFilterQuery.php
+++ b/src/Exceptions/InvalidFilterQuery.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Collection;
 
 class InvalidFilterQuery extends InvalidQuery
 {
+    /**
+     * @param Collection<int,non-empty-string> $unknownFilters
+     * @param Collection<int,non-empty-string> $allowedFilters
+     */
     public function __construct(
         public Collection $unknownFilters,
         public Collection $allowedFilters
@@ -18,6 +22,10 @@ class InvalidFilterQuery extends InvalidQuery
         parent::__construct(Response::HTTP_BAD_REQUEST, $message);
     }
 
+    /**
+     * @param Collection<int,non-empty-string> $unknownFilters
+     * @param Collection<int,non-empty-string> $allowedFilters
+     */
     public static function filtersNotAllowed(Collection $unknownFilters, Collection $allowedFilters): static
     {
         return new static(...func_get_args());

--- a/src/Exceptions/InvalidSortQuery.php
+++ b/src/Exceptions/InvalidSortQuery.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Collection;
 
 class InvalidSortQuery extends InvalidQuery
 {
+    /**
+     * @param Collection<int,non-empty-string> $unknownSorts
+     * @param Collection<int,non-empty-string> $allowedSorts
+     */
     public function __construct(
         public Collection $unknownSorts,
         public Collection $allowedSorts
@@ -19,6 +23,10 @@ class InvalidSortQuery extends InvalidQuery
         parent::__construct(Response::HTTP_BAD_REQUEST, $message);
     }
 
+    /**
+     * @param Collection<int,non-empty-string> $unknownSorts
+     * @param Collection<int,non-empty-string> $allowedSorts
+     */
     public static function sortsNotAllowed(Collection $unknownSorts, Collection $allowedSorts): static
     {
         return new static(...func_get_args());

--- a/src/Filters/Concerns/HandlesRelationConstraints.php
+++ b/src/Filters/Concerns/HandlesRelationConstraints.php
@@ -7,10 +7,16 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 trait HandlesRelationConstraints
 {
     protected array $relationConstraints = [];
 
+    /**
+     * @param Builder<TModel|\Illuminate\Database\Eloquent\Model> $query
+     */
     protected function isRelationProperty(Builder $query, string $property): bool
     {
         if (! Str::contains($property, '.')) {
@@ -30,6 +36,9 @@ trait HandlesRelationConstraints
         return is_a($query->getModel()->{$firstRelationship}(), Relation::class);
     }
 
+    /**
+     * @param Builder<TModel|\Illuminate\Database\Eloquent\Model> $query
+     */
     protected function withRelationConstraint(Builder $query, mixed $value, string $property): void
     {
         [$relation, $property] = collect(explode('.', $property))

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -5,12 +5,12 @@ namespace Spatie\QueryBuilder\Filters;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  */
 interface Filter
 {
     /**
-     * @param  Builder<TModelClass>  $query
+     * @param  Builder<TModel>  $query
      */
     public function __invoke(Builder $query, mixed $value, string $property): void;
 }

--- a/src/Filters/FiltersBeginsWith.php
+++ b/src/Filters/FiltersBeginsWith.php
@@ -3,9 +3,11 @@
 namespace Spatie\QueryBuilder\Filters;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @template-implements Filter<TModelClass>
+ * @template-implements Filter<TModel>
+ *
+ * @extends parent<TModel>
  */
 class FiltersBeginsWith extends FiltersPartial implements Filter
 {

--- a/src/Filters/FiltersBelongsTo.php
+++ b/src/Filters/FiltersBelongsTo.php
@@ -9,9 +9,9 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @template-implements Filter<TModelClass>
+ * @template-implements Filter<TModel>
  */
 class FiltersBelongsTo implements Filter
 {

--- a/src/Filters/FiltersCallback.php
+++ b/src/Filters/FiltersCallback.php
@@ -5,13 +5,15 @@ namespace Spatie\QueryBuilder\Filters;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @template-implements Filter<TModelClass>
+ * @template-implements Filter<TModel>
+ *
+ * @phpstan-type FiltersCallbackSchema callable(\Illuminate\Database\Eloquent\Builder<TModel>,mixed,non-empty-string): void
  */
 class FiltersCallback implements Filter
 {
-    /** @var callable */
+    /** @var FiltersCallbackSchema */
     private $callback;
 
     public function __construct(callable $callback)

--- a/src/Filters/FiltersEndsWith.php
+++ b/src/Filters/FiltersEndsWith.php
@@ -3,9 +3,11 @@
 namespace Spatie\QueryBuilder\Filters;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @template-implements Filter<TModelClass>
+ * @template-implements Filter<TModel>
+ *
+ * @extends parent<TModel>
  */
 class FiltersEndsWith extends FiltersPartial implements Filter
 {

--- a/src/Filters/FiltersExact.php
+++ b/src/Filters/FiltersExact.php
@@ -6,16 +6,20 @@ use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Filters\Concerns\HandlesRelationConstraints;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @template-implements Filter<TModelClass>
+ * @template-implements Filter<TModel>
  */
 class FiltersExact implements Filter
 {
+    /** @use HandlesRelationConstraints<TModel> */
     use HandlesRelationConstraints;
 
     public function __construct(protected bool $addRelationConstraint = true) {}
 
+    /**
+     * @param Builder<TModel|\Illuminate\Database\Eloquent\Model> $query
+     */
     public function __invoke(Builder $query, mixed $value, string $property): void
     {
         if ($this->addRelationConstraint && $this->isRelationProperty($query, $property)) {

--- a/src/Filters/FiltersGroup.php
+++ b/src/Filters/FiltersGroup.php
@@ -7,14 +7,16 @@ use InvalidArgumentException;
 use Spatie\QueryBuilder\AllowedFilter;
 
 /**
- * @template-implements Filter<\Illuminate\Database\Eloquent\Model>
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @template-implements Filter<TModel>
  */
 class FiltersGroup implements Filter
 {
-    /** @var AllowedFilter[] */
+    /** @var AllowedFilter<TModel>[] */
     protected array $members;
 
-    /** @param AllowedFilter[] $members */
+    /** @param AllowedFilter<TModel>[] $members */
     public function __construct(
         protected string $conjunction,
         array $members,

--- a/src/Filters/FiltersOperator.php
+++ b/src/Filters/FiltersOperator.php
@@ -7,12 +7,13 @@ use Spatie\QueryBuilder\Enums\FilterOperator;
 use Spatie\QueryBuilder\Filters\Concerns\HandlesRelationConstraints;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @template-implements Filter<TModelClass>
+ * @template-implements Filter<TModel>
  */
 class FiltersOperator implements Filter
 {
+    /** @use HandlesRelationConstraints<TModel> */
     use HandlesRelationConstraints;
 
     public function __construct(
@@ -21,6 +22,9 @@ class FiltersOperator implements Filter
         protected string $boolean,
     ) {}
 
+    /**
+     * @param Builder<TModel|\Illuminate\Database\Eloquent\Model> $query
+     */
     public function __invoke(Builder $query, mixed $value, string $property): void
     {
         $filterOperator = $this->filterOperator;

--- a/src/Filters/FiltersPartial.php
+++ b/src/Filters/FiltersPartial.php
@@ -6,16 +6,20 @@ use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\Filters\Concerns\HandlesRelationConstraints;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @template-implements Filter<TModelClass>
+ * @template-implements Filter<TModel>
  */
 class FiltersPartial implements Filter
 {
+    /** @use HandlesRelationConstraints<TModel> */
     use HandlesRelationConstraints;
 
     public function __construct(protected bool $addRelationConstraint = true) {}
 
+    /**
+     * @param Builder<TModel|\Illuminate\Database\Eloquent\Model> $query
+     */
     public function __invoke(Builder $query, mixed $value, string $property): void
     {
         if ($this->addRelationConstraint && $this->isRelationProperty($query, $property)) {

--- a/src/Filters/FiltersScope.php
+++ b/src/Filters/FiltersScope.php
@@ -14,9 +14,9 @@ use ReflectionUnionType;
 use Spatie\QueryBuilder\Exceptions\InvalidFilterValue;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @template-implements Filter<TModelClass>
+ * @template-implements Filter<TModel>
  */
 class FiltersScope implements Filter
 {
@@ -42,6 +42,9 @@ class FiltersScope implements Filter
         $query->$scope(...$values);
     }
 
+    /**
+     * @param Builder<TModel> $query
+     */
     protected function resolveParameters(Builder $query, array $values, string $scope): array
     {
         if (! $query->getModel()->hasNamedScope($scope)) {
@@ -65,7 +68,7 @@ class FiltersScope implements Filter
                 continue;
             }
 
-            /** @var TModelClass $model */
+            /** @var TModel $model */
             $model = $this->getClass($parameter)->newInstance();
             $index = $parameter->getPosition() - 1;
             $value = $values[$index];

--- a/src/Filters/FiltersTrashed.php
+++ b/src/Filters/FiltersTrashed.php
@@ -5,9 +5,9 @@ namespace Spatie\QueryBuilder\Filters;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
- * @template TModelClass of \Illuminate\Database\Eloquent\Model
+ * @template TModel of \Illuminate\Database\Eloquent\Model
  *
- * @template-implements Filter<TModelClass>
+ * @template-implements Filter<TModel>
  */
 class FiltersTrashed implements Filter
 {

--- a/src/Filters/FiltersTrashed.php
+++ b/src/Filters/FiltersTrashed.php
@@ -14,17 +14,17 @@ class FiltersTrashed implements Filter
     public function __invoke(Builder $query, mixed $value, string $property): void
     {
         if ($value === 'with') {
-            $query->withTrashed();
+            $query->withTrashed(); // @phpstan-ignore-line
 
             return;
         }
 
         if ($value === 'only') {
-            $query->onlyTrashed();
+            $query->onlyTrashed(); // @phpstan-ignore-line
 
             return;
         }
 
-        $query->withoutTrashed();
+        $query->withoutTrashed(); // @phpstan-ignore-line
     }
 }

--- a/src/Includes/IncludedCallback.php
+++ b/src/Includes/IncludedCallback.php
@@ -5,8 +5,14 @@ namespace Spatie\QueryBuilder\Includes;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @phpstan-type IncludedCallbackSchema (Closure(\Illuminate\Database\Eloquent\Relations\Relation<*,*,*>): mixed)
+ */
 class IncludedCallback implements IncludeInterface
 {
+    /**
+     * @param IncludedCallbackSchema $callback
+     */
     public function __construct(protected Closure $callback) {}
 
     public function __invoke(Builder $query, string $relation): void

--- a/src/Includes/IncludedCount.php
+++ b/src/Includes/IncludedCount.php
@@ -14,7 +14,7 @@ class IncludedCount implements IncludeInterface
 
     public function __invoke(Builder $query, string $count): void
     {
-        $suffix = config('query-builder.suffixes.count', 'Count');
+        $suffix = config()->string('query-builder.suffixes.count', 'Count');
         $relation = Str::endsWith($count, $suffix) ? Str::beforeLast($count, $suffix) : $count;
 
         $query->withCount($this->constraint ? [$relation => $this->constraint] : $relation);

--- a/src/Includes/IncludedExists.php
+++ b/src/Includes/IncludedExists.php
@@ -14,7 +14,7 @@ class IncludedExists implements IncludeInterface
 
     public function __invoke(Builder $query, string $exists): void
     {
-        $exists = Str::before($exists, config('query-builder.suffixes.exists', 'Exists'));
+        $exists = Str::before($exists, config()->string('query-builder.suffixes.exists', 'Exists'));
 
         $query
             ->withExists($this->constraint ? [$exists => $this->constraint] : $exists)

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -20,14 +20,15 @@ use Spatie\QueryBuilder\Concerns\SortsQuery;
  */
 class QueryBuilder implements ArrayAccess
 {
-    use AddsFieldsToQuery;
-    use AddsIncludesToQuery;
-    use FiltersQuery;
-    use ForwardsCalls;
     /**
+     * @use FiltersQuery<TModel>
      * @use SortsQuery<TModel>
      */
-    use SortsQuery;
+    use AddsFieldsToQuery,
+        AddsIncludesToQuery,
+        FiltersQuery,
+        ForwardsCalls,
+        SortsQuery;
 
     protected QueryBuilderRequest $request;
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -24,6 +24,9 @@ class QueryBuilder implements ArrayAccess
     use AddsIncludesToQuery;
     use FiltersQuery;
     use ForwardsCalls;
+    /**
+     * @use SortsQuery<TModel>
+     */
     use SortsQuery;
 
     protected QueryBuilderRequest $request;

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -53,18 +53,27 @@ class QueryBuilderRequest extends Request
         return collect($this->toParameterArray($appendParts))->filter();
     }
 
+    /**
+     * @return Collection<non-empty-string, list<non-empty-string>>
+     */
     public function fields(): Collection
     {
         $fieldsParameterName = config()->string('query-builder.parameters.fields', 'fields');
 
         $fieldsData = $this->getRequestData($fieldsParameterName);
 
+        /**
+         * @var Collection<non-empty-string, non-empty-string>
+         */
         $fieldsPerTable = collect($this->toParameterArray($fieldsData));
 
         if ($fieldsPerTable->isEmpty()) {
             return collect();
         }
 
+        /**
+         * @var array<non-empty-string, list<non-empty-string>>
+         */
         $fields = [];
 
         $fieldsPerTable->each(function ($tableFields, $model) use (&$fields) {
@@ -83,9 +92,15 @@ class QueryBuilderRequest extends Request
             $fields[$model] = array_merge($fields[$model], $tableFields);
         });
 
+        /**
+         * @var Collection<non-empty-string, list<non-empty-string>>
+         */
         return collect($fields);
     }
 
+    /**
+     * @return Collection<int, non-empty-string>
+     */
     public function sorts(): Collection
     {
         $sortParameterName = config()->string('query-builder.parameters.sort', 'sort');
@@ -102,17 +117,23 @@ class QueryBuilderRequest extends Request
     {
         $filterParameterName = config()->string('query-builder.parameters.filter', 'filter');
 
+        /**
+         * @var array<non-empty-string,mixed>
+         */
         $filterParts = $this->getRequestData($filterParameterName, []);
 
         if (is_string($filterParts)) {
             return collect();
         }
 
+        /**
+         * @var Collection<non-empty-string,mixed>
+         */
         $filters = collect($filterParts);
 
-        return $filters->map(function ($value) {
-            return $this->getFilterValue($value);
-        });
+        return $filters->map(
+            fn(mixed $value) => $this->getFilterValue($value)
+        );
     }
 
     protected function getFilterValue(mixed $value): mixed

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -37,7 +37,7 @@ class QueryBuilderRequest extends Request
 
     public function includes(): Collection
     {
-        $includeParameterName = config('query-builder.parameters.include', 'include');
+        $includeParameterName = config()->string('query-builder.parameters.include', 'include');
 
         $includeParts = $this->getRequestData($includeParameterName);
 
@@ -46,7 +46,7 @@ class QueryBuilderRequest extends Request
 
     public function appends(): Collection
     {
-        $appendParameterName = config('query-builder.parameters.append', 'append');
+        $appendParameterName = config()->string('query-builder.parameters.append', 'append');
 
         $appendParts = $this->getRequestData($appendParameterName);
 
@@ -55,7 +55,8 @@ class QueryBuilderRequest extends Request
 
     public function fields(): Collection
     {
-        $fieldsParameterName = config('query-builder.parameters.fields', 'fields');
+        $fieldsParameterName = config()->string('query-builder.parameters.fields', 'fields');
+
         $fieldsData = $this->getRequestData($fieldsParameterName);
 
         $fieldsPerTable = collect($this->toParameterArray($fieldsData));
@@ -87,7 +88,7 @@ class QueryBuilderRequest extends Request
 
     public function sorts(): Collection
     {
-        $sortParameterName = config('query-builder.parameters.sort', 'sort');
+        $sortParameterName = config()->string('query-builder.parameters.sort', 'sort');
 
         $sortParts = $this->getRequestData($sortParameterName);
 
@@ -99,7 +100,7 @@ class QueryBuilderRequest extends Request
      */
     public function filters(): Collection
     {
-        $filterParameterName = config('query-builder.parameters.filter', 'filter');
+        $filterParameterName = config()->string('query-builder.parameters.filter', 'filter');
 
         $filterParts = $this->getRequestData($filterParameterName, []);
 
@@ -144,6 +145,6 @@ class QueryBuilderRequest extends Request
 
     protected function delimiter(): string
     {
-        return config('query-builder.delimiter', ',');
+        return config()->string('query-builder.delimiter', ',');
     }
 }

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -115,7 +115,8 @@ class QueryBuilderRequest extends Request
      */
     public function filters(): Collection
     {
-        $filterParameterName = config()->string('query-builder.parameters.filter', 'filter');
+        /** @var ?non-empty-string */
+        $filterParameterName = config('query-builder.parameters.filter', 'filter');
 
         /**
          * @var array<non-empty-string,mixed>

--- a/src/QueryBuilderRequest.php
+++ b/src/QueryBuilderRequest.php
@@ -94,6 +94,9 @@ class QueryBuilderRequest extends Request
         return collect($this->toParameterArray($sortParts))->filter();
     }
 
+    /**
+     * @return Collection<non-empty-string,mixed>
+     */
     public function filters(): Collection
     {
         $filterParameterName = config('query-builder.parameters.filter', 'filter');

--- a/src/QueryBuilderServiceProvider.php
+++ b/src/QueryBuilderServiceProvider.php
@@ -20,7 +20,9 @@ class QueryBuilderServiceProvider extends PackageServiceProvider
             return QueryBuilderRequest::fromRequest($app['request']);
         });
     }
-
+    /**
+     * @return list<class-string>
+     */
     public function provides(): array
     {
         return [

--- a/src/Sorts/Sort.php
+++ b/src/Sorts/Sort.php
@@ -4,7 +4,14 @@ namespace Spatie\QueryBuilder\Sorts;
 
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ */
 interface Sort
 {
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<TModel> $query
+     * @param non-empty-string $property
+     */
     public function __invoke(Builder $query, bool $descending, string $property): void;
 }

--- a/src/Sorts/SortsCallback.php
+++ b/src/Sorts/SortsCallback.php
@@ -4,11 +4,21 @@ namespace Spatie\QueryBuilder\Sorts;
 
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @template-implements Sort<TModel>
+ *
+ * @phpstan-type SortsCallbackSchema callable(\Illuminate\Database\Eloquent\Builder<TModel>,bool,non-empty-string):void
+ */
 class SortsCallback implements Sort
 {
-    /** @var callable */
+    /** @var SortsCallbackSchema */
     private $callback;
 
+    /**
+     * @param SortsCallbackSchema $callback
+     */
     public function __construct(callable $callback)
     {
         $this->callback = $callback;

--- a/src/Sorts/SortsField.php
+++ b/src/Sorts/SortsField.php
@@ -4,6 +4,11 @@ namespace Spatie\QueryBuilder\Sorts;
 
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @template-implements Sort<TModel>
+ */
 class SortsField implements Sort
 {
     public function __invoke(Builder $query, bool $descending, string $property): void


### PR DESCRIPTION
## Summary

Hey @freekmurze (and friends),

This is **part 1** of a PHPStan cleanup. As someone who reviews PRs for a living, I refuse to dump a 2000-line "fix all the types" bomb on your desk. If this direction looks good, I'll keep chipping away in smaller follow-ups.

**TL;DR:** fewer ignored errors, better types on filters/sorts, typed config accessors, and the baseline lost roughly half its weight.

### What changed

**PHPStan hygiene**
- Removed `reportUnmatchedIgnoredErrors: false`. If we ignore an error that never happens, PHPStan should complain. Ghost ignores are not a vibe.
- Trimmed a bunch of entries from `phpstan-baseline.neon` that no longer match reality.

**Typed config getters**  
Switched `config('…')` calls to Laravel's typed helpers (`config()->boolean()`, `config()->string()`, …) introduced in [laravel/framework#50140](https://github.com/laravel/framework/pull/50140). Same runtime behavior, happier static analysis.

**Generics on Filters & Sorts**
- `Filter` / `Sort` (and their implementations) now carry a `TModel` template.
- Callback shapes are documented via `@phpstan-type` (`FiltersCallbackSchema` / `SortsCallbackSchema`).
- `AllowedFilter` / `AllowedSort` / related query concerns follow along.
- Names and internal names use `non-empty-string` (and similar richer string types) so PHPStan can catch empty filter/sort names before they sneak in.

**Small behavioral / correctness tweaks**
- `AllowedFilter::unsetDefault()` now sets `$default = null` instead of `unset()`. Destroying the property breaks subclasses that still expect it to exist (and PHPStan was right to yell about it).
- `getIgnored()` uses `->all()` instead of `->toArray()`. Same values, no unnecessary key remapping.

**Also typed along the way**
- Exception collection parameters (`InvalidFilterQuery`, `InvalidSortQuery`, `InvalidAppendQuery`)
- `AllowedInclude`, factory templates, service provider `provides()` return type
- A few `static` closures where PHPStan / runtime happily allow it

### Why not everything at once?

Because nobody enjoys reviewing a PR that looks like PHPStan wrote a novel. This slice is self-contained and already removes a solid chunk of baseline noise. More to come if you're happy with the approach.

## Test plan

- [ ] Existing test suite still green
- [ ] `vendor/bin/phpstan analyse` runs clean against the updated baseline
- [ ] Filters / sorts / includes behave the same (especially defaults, ignored values, and config-driven suffixes/delimiters)

---

If this looks good, part 2 will keep eating the remaining baseline. If anything feels too spicy, happy to adjust before continuing.