### PR TITLE
Default direction getter for AllowedSort

### DIFF
--- a/src/AllowedSort.php
+++ b/src/AllowedSort.php
@@ -90,4 +90,9 @@ class AllowedSort
 
         return $this;
     }
+
+    public function getDefaultDirection(): SortDirection
+    {
+        return $this->defaultDirection;
+    }
 }


### PR DESCRIPTION
In my project I would like to be able to get the default direction of an `AllowedSort`. Because the property is protected this will add a getter for it similar to `name` and `internalName`.