### PR TITLE
Allow model-specific custom filters, sorts and includes

### DIFF
--- a/docs/features/filtering.md
+++ b/docs/features/filtering.md
@@ -338,6 +338,8 @@ $users = QueryBuilder::for(User::class)
 // $users will contain all users that have the `createPosts` permission
 ```
 
+The `@implements` annotation is only there for static analysis. Use `Filter<Model>` for a filter that works on any model, or name a concrete model (`Filter<User>`) when the filter is written for one. The same goes for the `Sort` and `IncludeInterface` interfaces.
+
 ## Filter aliases
 
 It can be useful to specify an alias for a filter to avoid exposing database column names. For example, your users table might have a `user_passport_full_name` column, which is a horrible name for a filter. Using aliases you can specify a new, shorter name for this filter:

--- a/src/AllowedFilter.php
+++ b/src/AllowedFilter.php
@@ -38,7 +38,7 @@ class AllowedFilter
     protected ?string $arrayValueDelimiter = null;
 
     /**
-     * @param  Filter<Model>  $filterClass
+     * @param  Filter<*>  $filterClass
      */
     public function __construct(
         protected string $name,
@@ -130,7 +130,7 @@ class AllowedFilter
     }
 
     /**
-     * @param  Filter<Model>  $filterClass
+     * @param  Filter<*>  $filterClass
      */
     public static function custom(string $name, Filter $filterClass, ?string $internalName = null): static
     {
@@ -164,7 +164,7 @@ class AllowedFilter
     }
 
     /**
-     * @return Filter<Model>
+     * @return Filter<*>
      */
     public function getFilterClass(): Filter
     {

--- a/src/AllowedInclude.php
+++ b/src/AllowedInclude.php
@@ -3,7 +3,6 @@
 namespace Spatie\QueryBuilder;
 
 use Closure;
-use Illuminate\Database\Eloquent\Model;
 use Spatie\QueryBuilder\Includes\IncludedAvg;
 use Spatie\QueryBuilder\Includes\IncludedCallback;
 use Spatie\QueryBuilder\Includes\IncludedCount;
@@ -22,7 +21,7 @@ class AllowedInclude
     protected string $internalName;
 
     /**
-     * @param  IncludeInterface<Model>  $includeClass
+     * @param  IncludeInterface<*>  $includeClass
      */
     public function __construct(
         protected string $name,
@@ -73,7 +72,7 @@ class AllowedInclude
     }
 
     /**
-     * @param  IncludeInterface<Model>  $includeClass
+     * @param  IncludeInterface<*>  $includeClass
      */
     public static function custom(string $name, IncludeInterface $includeClass, ?string $internalName = null): static
     {

--- a/src/AllowedSort.php
+++ b/src/AllowedSort.php
@@ -19,7 +19,7 @@ class AllowedSort
     protected string $internalName;
 
     /**
-     * @param  Sort<Model>  $sortClass
+     * @param  Sort<*>  $sortClass
      */
     public function __construct(
         protected string $name,
@@ -54,7 +54,7 @@ class AllowedSort
     }
 
     /**
-     * @param  Sort<Model>  $sortClass
+     * @param  Sort<*>  $sortClass
      */
     public static function custom(string $name, Sort $sortClass, ?string $internalName = null): static
     {

--- a/types/query-builder.php
+++ b/types/query-builder.php
@@ -8,6 +8,7 @@ use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\AllowedSort;
 use Spatie\QueryBuilder\Enums\FilterOperator;
 use Spatie\QueryBuilder\Filters\Filter;
+use Spatie\QueryBuilder\Includes\IncludeInterface;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\Sorts\Sort;
 
@@ -27,7 +28,9 @@ class Book extends Model
 class Author extends Model {}
 
 /**
- * @implements Filter<Model>
+ * A filter written against one specific model.
+ *
+ * @implements Filter<Book>
  */
 class BooksPublishedInFilter implements Filter
 {
@@ -38,13 +41,37 @@ class BooksPublishedInFilter implements Filter
 }
 
 /**
- * @implements Sort<Model>
+ * A filter written against any model.
+ *
+ * @implements Filter<Model>
+ */
+class NotNullFilter implements Filter
+{
+    public function __invoke(Builder $query, mixed $value, string $property): void
+    {
+        $query->whereNotNull($property);
+    }
+}
+
+/**
+ * @implements Sort<Book>
  */
 class BooksByPopularitySort implements Sort
 {
     public function __invoke(Builder $query, bool $descending, string $property): void
     {
         $query->orderBy('popularity', $descending ? 'desc' : 'asc');
+    }
+}
+
+/**
+ * @implements IncludeInterface<Book>
+ */
+class BooksWithAuthorInclude implements IncludeInterface
+{
+    public function __invoke(Builder $query, string $include): void
+    {
+        $query->with('author');
     }
 }
 
@@ -62,6 +89,7 @@ assertType('Spatie\QueryBuilder\QueryBuilder<Book>', QueryBuilder::for(Book::cla
         AllowedFilter::operator('pages', FilterOperator::GREATER_THAN),
         AllowedFilter::callback('title_length', fn (Builder $query, mixed $value) => $query->whereRaw('length(title) = ?', [$value])),
         AllowedFilter::custom('published_in', new BooksPublishedInFilter),
+        AllowedFilter::custom('subtitle', new NotNullFilter),
         AllowedFilter::groupOr('search', [
             AllowedFilter::partial('title'),
             AllowedFilter::partial('author.name'),
@@ -77,4 +105,5 @@ assertType('Spatie\QueryBuilder\QueryBuilder<Book>', QueryBuilder::for(Book::cla
         'author',
         AllowedInclude::count('reviewsCount'),
         AllowedInclude::callback('recentReviews', fn (Builder $query) => $query->latest()),
+        AllowedInclude::custom('authorDetails', new BooksWithAuthorInclude),
     ));


### PR DESCRIPTION
Fixes #1068.

Since #1066, `AllowedFilter::custom()` was annotated `Filter<Model>`. PHPStan generics are invariant, so a filter annotated for a concrete model was rejected:

```
Filter<Post> given, Filter<Model> expected
```

`AllowedSort::custom()` and `AllowedInclude::custom()` had the same problem.

These classes never inspect which model the filter targets, so the annotation asserted more than the code needs. Using the generic wildcard (`Filter<*>`) accepts both `Filter<Model>` and `Filter<Post>`.

`types/query-builder.php` now covers a model-specific filter, sort and include, so this cannot regress. Without the fix it produces 4 errors.